### PR TITLE
Quick draft: Add cortex-m

### DIFF
--- a/examples/arm-hello/config.yaml
+++ b/examples/arm-hello/config.yaml
@@ -1,0 +1,33 @@
+#                               POK header
+#
+# The following file is a part of the POK project. Any modification should
+# be made according to the POK licence. You CANNOT use this file or a part
+# of a file for your own project.
+#
+# For more information on the POK licence, please see our LICENCE FILE
+#
+# Please follow the coding guidelines described in doc/CODING_GUIDELINES
+#
+#                                      Copyright (c) 2007-2025 POK team
+
+target:
+    arch: arm
+    bsp: stm32f4
+
+partitions:
+    - name: part1
+      features: [assert, console, libc]
+      scheduler: RR
+      threads:
+          count: 2
+          features: [sleep, suspend]
+      size: 16kB
+      objects: ["main.o"]
+
+kernel:
+    features: [debug]
+    scheduler:
+        major_frame: 1s
+        slots:
+            - partition: part1
+              duration: 1s

--- a/examples/arm-hello/main.c
+++ b/examples/arm-hello/main.c
@@ -1,0 +1,69 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file examples/arm-hello/main.c
+ * \brief Simple ARM Cortex-M hello world example
+ */
+
+#include <libc/stdio.h>
+#include <core/thread.h>
+#include <core/time.h>
+
+void thread1_job(void) {
+  int i = 0;
+  
+  while (1) {
+    printf("Hello from ARM Cortex-M thread 1, iteration %d\n", i++);
+    pok_thread_sleep(1000);  /* Sleep for 1 second */
+  }
+}
+
+void thread2_job(void) {
+  int i = 0;
+  
+  while (1) {
+    printf("Hello from ARM Cortex-M thread 2, iteration %d\n", i++);
+    pok_thread_sleep(1500);  /* Sleep for 1.5 seconds */
+  }
+}
+
+int main(void) {
+  pok_ret_t ret;
+  uint32_t tid1, tid2;
+  
+  printf("POK ARM Cortex-M Hello World Example\n");
+  printf("====================================\n");
+  
+  /* Create first thread */
+  ret = pok_thread_create(&tid1, thread1_job, 1024, 1, 0);
+  if (ret != POK_ERRNO_OK) {
+    printf("Error creating thread 1: %d\n", ret);
+    return -1;
+  }
+  
+  /* Create second thread */
+  ret = pok_thread_create(&tid2, thread2_job, 1024, 1, 0);
+  if (ret != POK_ERRNO_OK) {
+    printf("Error creating thread 2: %d\n", ret);
+    return -1;
+  }
+  
+  printf("Threads created successfully. Starting scheduler...\n");
+  
+  /* Start the threads */
+  pok_partition_set_mode(POK_PARTITION_MODE_NORMAL);
+  
+  return 0;
+}

--- a/kernel/arch/Makefile
+++ b/kernel/arch/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/misc/mk/config.mk
 ifdef ARCH
 SUBDIRS:=$(ARCH)
 else
-SUBDIRS:=ppc sparc x86
+SUBDIRS:=arm ppc sparc x86
 endif
 
 LO_TARGET=	arch.lo

--- a/kernel/arch/arm/Makefile
+++ b/kernel/arch/arm/Makefile
@@ -13,8 +13,33 @@ LO_OBJS=	arch.o \
 		mpu.o \
 		nvic.o
 
-LO_DEPS=
+LO_DEPS=	$(BSP)/$(BSP).lo
 
 include $(TOPDIR)/misc/mk/objdir.mk
+
+all: $(LO_TARGET)
+
+$(OBJ_DIR)/$(BSP)/$(BSP).lo::
+	$(CD) $(BSP) && $(MAKE)
+
+.PHONY: clean distclean depend all
+
+clean: common-clean
+ifdef BSP
+	$(CD) $(BSP) && $(MAKE) clean
+endif
+
+distclean: clean
+	$(RM) .depend.mk
+ifdef BSP
+	$(CD) $(BSP) && $(MAKE) distclean
+endif
+
+depend:
+	$(if $(LO_OBJS), $(CC) $(CFLAGS) -MM $(wildcard *.c) $(wildcard *.S) > .depend.mk,)
+ifdef BSP
+	$(CD) $(BSP) && $(MAKE) depend
+endif
+
 include $(TOPDIR)/misc/mk/rules-common.mk
 include $(TOPDIR)/misc/mk/rules-kernel.mk

--- a/kernel/arch/arm/Makefile
+++ b/kernel/arch/arm/Makefile
@@ -1,0 +1,20 @@
+TOPDIR=		../../../
+
+include $(TOPDIR)/misc/mk/config.mk
+-include $(TOPDIR)/misc/mk/common-$(ARCH).mk
+
+LO_TARGET=	arm.lo
+
+LO_OBJS=	arch.o \
+		space.o \
+		thread.o \
+		syscalls.o \
+		exceptions.o \
+		mpu.o \
+		nvic.o
+
+LO_DEPS=
+
+include $(TOPDIR)/misc/mk/objdir.mk
+include $(TOPDIR)/misc/mk/rules-common.mk
+include $(TOPDIR)/misc/mk/rules-kernel.mk

--- a/kernel/arch/arm/arch.c
+++ b/kernel/arch/arm/arch.c
@@ -1,0 +1,72 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/arch.c
+ * \author  POK team
+ * \brief   Provides generic architecture interface for ARM Cortex-M architecture
+ */
+
+#include "mpu.h"
+#include "nvic.h"
+#include <core/partition.h>
+#include <errno.h>
+#include <arch.h>
+
+extern void pok_arch_space_init(void);
+
+pok_ret_t pok_arch_init() {
+  pok_mpu_init();
+  pok_nvic_init();
+  pok_arch_space_init();
+
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_arch_preempt_disable() {
+  __asm volatile ("cpsid i" : : : "memory");
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_arch_preempt_enable() {
+  __asm volatile ("cpsie i" : : : "memory");
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_arch_idle() {
+  while (1) {
+    __asm volatile ("wfi");
+  }
+}
+
+pok_ret_t pok_arch_event_register(uint8_t vector, void (*handler)(void)) {
+  return pok_nvic_set_handler(vector, handler);
+}
+
+uint32_t pok_thread_stack_addr(const uint8_t partition_id,
+                               const uint32_t local_thread_id) {
+  return pok_partitions[partition_id].size - 8 -
+         (local_thread_id * POK_USER_STACK_SIZE);
+}
+
+__attribute__((noreturn)) void pok_division_by_zero_error(void) {
+  /* Force a division by zero to trigger HardFault */
+  volatile int zero = 0;
+  volatile int result = 42 / zero;
+  (void)result;
+  
+  while (1) {
+    __asm volatile ("wfi");
+  }
+}

--- a/kernel/arch/arm/arch.c
+++ b/kernel/arch/arm/arch.c
@@ -29,12 +29,19 @@ extern pok_ret_t pok_arch_space_init(void);
 pok_ret_t pok_arch_init() {
   pok_ret_t ret;
   
-  pok_mpu_init();
-  pok_nvic_init();
+  ret = pok_mpu_init();
+  if (ret != POK_ERRNO_OK) {
+    return (ret);
+  }
+  
+  ret = pok_nvic_init();
+  if (ret != POK_ERRNO_OK) {
+    return (ret);
+  }
   
   ret = pok_arch_space_init();
   if (ret != POK_ERRNO_OK) {
-    return ret;
+    return (ret);
   }
 
   return (POK_ERRNO_OK);
@@ -57,7 +64,7 @@ pok_ret_t pok_arch_idle() {
 }
 
 pok_ret_t pok_arch_event_register(uint8_t vector, void (*handler)(void)) {
-  return pok_nvic_set_handler(vector, handler);
+  return (pok_nvic_set_handler(vector, handler));
 }
 
 uint32_t pok_thread_stack_addr(const uint8_t partition_id,

--- a/kernel/arch/arm/arch.c
+++ b/kernel/arch/arm/arch.c
@@ -15,30 +15,31 @@
 /**
  * \file    arch/arm/arch.c
  * \author  POK team
- * \brief   Provides generic architecture interface for ARM Cortex-M architecture
+ * \brief   Provides generic architecture interface for ARM Cortex-M
+ * architecture
  */
 
 #include "mpu.h"
 #include "nvic.h"
+#include <arch.h>
 #include <core/partition.h>
 #include <errno.h>
-#include <arch.h>
 
 extern pok_ret_t pok_arch_space_init(void);
 
 pok_ret_t pok_arch_init() {
   pok_ret_t ret;
-  
+
   ret = pok_mpu_init();
   if (ret != POK_ERRNO_OK) {
     return (ret);
   }
-  
+
   ret = pok_nvic_init();
   if (ret != POK_ERRNO_OK) {
     return (ret);
   }
-  
+
   ret = pok_arch_space_init();
   if (ret != POK_ERRNO_OK) {
     return (ret);
@@ -48,18 +49,18 @@ pok_ret_t pok_arch_init() {
 }
 
 pok_ret_t pok_arch_preempt_disable() {
-  __asm volatile ("cpsid i" : : : "memory");
+  __asm volatile("cpsid i" : : : "memory");
   return (POK_ERRNO_OK);
 }
 
 pok_ret_t pok_arch_preempt_enable() {
-  __asm volatile ("cpsie i" : : : "memory");
+  __asm volatile("cpsie i" : : : "memory");
   return (POK_ERRNO_OK);
 }
 
 pok_ret_t pok_arch_idle() {
   while (1) {
-    __asm volatile ("wfi");
+    __asm volatile("wfi");
   }
 }
 
@@ -78,8 +79,8 @@ __attribute__((noreturn)) void pok_division_by_zero_error(void) {
   volatile int zero = 0;
   volatile int result = 42 / zero;
   (void)result;
-  
+
   while (1) {
-    __asm volatile ("wfi");
+    __asm volatile("wfi");
   }
 }

--- a/kernel/arch/arm/arch.c
+++ b/kernel/arch/arm/arch.c
@@ -24,12 +24,18 @@
 #include <errno.h>
 #include <arch.h>
 
-extern void pok_arch_space_init(void);
+extern pok_ret_t pok_arch_space_init(void);
 
 pok_ret_t pok_arch_init() {
+  pok_ret_t ret;
+  
   pok_mpu_init();
   pok_nvic_init();
-  pok_arch_space_init();
+  
+  ret = pok_arch_space_init();
+  if (ret != POK_ERRNO_OK) {
+    return ret;
+  }
 
   return (POK_ERRNO_OK);
 }

--- a/kernel/arch/arm/exceptions.c
+++ b/kernel/arch/arm/exceptions.c
@@ -1,0 +1,158 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/exceptions.c
+ * \author  POK team
+ * \brief   ARM Cortex-M exception handling
+ */
+
+#include "nvic.h"
+#include "mpu.h"
+#include <core/debug.h>
+#include <core/partition.h>
+#include <errno.h>
+
+/*
+ * Memory Management Fault Handler
+ * Handles MPU violations and other memory management faults
+ */
+void MemManage_Handler(void) {
+  uint32_t *frame;
+  uint32_t fault_addr;
+  uint8_t partition_id;
+  
+  /* Get stack frame */
+  __asm volatile ("mrs %0, psp" : "=r" (frame));
+  
+  /* Get faulting address from MemManage Fault Address Register */
+  fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x34)); /* MMFAR */
+  
+  /* Get current partition */
+  extern uint8_t pok_current_partition;
+  partition_id = pok_current_partition;
+  
+#ifdef POK_NEEDS_DEBUG
+  printf("MemManage fault in partition %d at address 0x%x\n", 
+         partition_id, fault_addr);
+  printf("PC: 0x%x, LR: 0x%x\n", frame[6], frame[5]);
+#endif
+  
+  /* Handle partition isolation violation */
+  if (partition_id < POK_CONFIG_NB_PARTITIONS) {
+    /* Terminate the offending partition */
+    pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
+    
+    /* Force a reschedule to switch away from this partition */
+    pok_sched();
+  }
+  
+  /* If we reach here, halt the system */
+  while (1) {
+    __asm volatile ("wfi");
+  }
+}
+
+/*
+ * Bus Fault Handler
+ * Handles bus errors and invalid memory accesses
+ */
+void BusFault_Handler(void) {
+  uint32_t *frame;
+  uint32_t fault_addr;
+  uint8_t partition_id;
+  
+  __asm volatile ("mrs %0, psp" : "=r" (frame));
+  
+  /* Get faulting address from Bus Fault Address Register */
+  fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x38)); /* BFAR */
+  
+  extern uint8_t pok_current_partition;
+  partition_id = pok_current_partition;
+  
+#ifdef POK_NEEDS_DEBUG
+  printf("BusFault in partition %d at address 0x%x\n", 
+         partition_id, fault_addr);
+  printf("PC: 0x%x, LR: 0x%x\n", frame[6], frame[5]);
+#endif
+  
+  if (partition_id < POK_CONFIG_NB_PARTITIONS) {
+    pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
+    pok_sched();
+  }
+  
+  while (1) {
+    __asm volatile ("wfi");
+  }
+}
+
+/*
+ * Usage Fault Handler  
+ * Handles undefined instruction, unaligned access, etc.
+ */
+void UsageFault_Handler(void) {
+  uint32_t *frame;
+  uint8_t partition_id;
+  
+  __asm volatile ("mrs %0, psp" : "=r" (frame));
+  
+  extern uint8_t pok_current_partition;
+  partition_id = pok_current_partition;
+  
+#ifdef POK_NEEDS_DEBUG
+  printf("UsageFault in partition %d\n", partition_id);
+  printf("PC: 0x%x, LR: 0x%x\n", frame[6], frame[5]);
+#endif
+  
+  if (partition_id < POK_CONFIG_NB_PARTITIONS) {
+    pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
+    pok_sched();
+  }
+  
+  while (1) {
+    __asm volatile ("wfi");
+  }
+}
+
+/*
+ * Hard Fault Handler
+ * Last resort fault handler
+ */
+void HardFault_Handler(void) {
+  uint32_t *frame;
+  uint8_t partition_id;
+  
+  __asm volatile ("mrs %0, psp" : "=r" (frame));
+  
+  extern uint8_t pok_current_partition;
+  partition_id = pok_current_partition;
+  
+#ifdef POK_NEEDS_DEBUG
+  printf("HardFault in partition %d\n", partition_id);
+  printf("PC: 0x%x, LR: 0x%x, PSR: 0x%x\n", frame[6], frame[5], frame[7]);
+  printf("r0: 0x%x, r1: 0x%x, r2: 0x%x, r3: 0x%x\n", 
+         frame[0], frame[1], frame[2], frame[3]);
+#endif
+  
+  /* Try to recover by stopping the current partition */
+  if (partition_id < POK_CONFIG_NB_PARTITIONS) {
+    pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
+    pok_sched();
+  }
+  
+  /* If recovery fails, halt the system */
+  while (1) {
+    __asm volatile ("wfi");
+  }
+}

--- a/kernel/arch/arm/exceptions.c
+++ b/kernel/arch/arm/exceptions.c
@@ -24,29 +24,48 @@
 #include <core/partition.h>
 #include <errno.h>
 
+/* CFSR (Configurable Fault Status Register) bits */
+#define SCB_CFSR    (*((volatile uint32_t *)(SCB_BASE + 0x28)))
+#define CFSR_MMARVALID  (1 << 7)   /* MemManage Fault Address Register valid */
+#define CFSR_BFARVALID  (1 << 15)  /* Bus Fault Address Register valid */
+
 /*
  * Memory Management Fault Handler
  * Handles MPU violations and other memory management faults
  */
 void MemManage_Handler(void) {
   uint32_t *frame;
-  uint32_t fault_addr;
+  uint32_t fault_addr = 0;
   uint8_t partition_id;
+  uint32_t cfsr;
   
   /* Get stack frame */
   __asm volatile ("mrs %0, psp" : "=r" (frame));
   
-  /* Get faulting address from MemManage Fault Address Register */
-  fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x34)); /* MMFAR */
+  /* Read CFSR to check fault status */
+  cfsr = SCB_CFSR;
+  
+  /* Get faulting address from MemManage Fault Address Register if valid */
+  if (cfsr & CFSR_MMARVALID) {
+    fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x34)); /* MMFAR */
+  }
+  
+  /* Clear MemManage fault flags in CFSR */
+  SCB_CFSR = cfsr & 0xFF;  /* Clear MMFSR bits */
   
   /* Get current partition */
   extern uint8_t pok_current_partition;
   partition_id = pok_current_partition;
   
 #ifdef POK_NEEDS_DEBUG
-  printf("MemManage fault in partition %d at address 0x%x\n", 
-         partition_id, fault_addr);
-  printf("PC: 0x%x, LR: 0x%x\n", frame[6], frame[5]);
+  if (cfsr & CFSR_MMARVALID) {
+    printf("MemManage fault in partition %d at address 0x%x\n", 
+           partition_id, fault_addr);
+  } else {
+    printf("MemManage fault in partition %d (address not available)\n", 
+           partition_id);
+  }
+  printf("PC: 0x%x, LR: 0x%x, CFSR: 0x%x\n", frame[6], frame[5], cfsr);
 #endif
   
   /* Handle partition isolation violation */
@@ -70,21 +89,35 @@ void MemManage_Handler(void) {
  */
 void BusFault_Handler(void) {
   uint32_t *frame;
-  uint32_t fault_addr;
+  uint32_t fault_addr = 0;
   uint8_t partition_id;
+  uint32_t cfsr;
   
   __asm volatile ("mrs %0, psp" : "=r" (frame));
   
-  /* Get faulting address from Bus Fault Address Register */
-  fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x38)); /* BFAR */
+  /* Read CFSR to check fault status */
+  cfsr = SCB_CFSR;
+  
+  /* Get faulting address from Bus Fault Address Register if valid */
+  if (cfsr & CFSR_BFARVALID) {
+    fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x38)); /* BFAR */
+  }
+  
+  /* Clear Bus fault flags in CFSR */
+  SCB_CFSR = (cfsr & 0xFF00) >> 8;  /* Clear BFSR bits */
   
   extern uint8_t pok_current_partition;
   partition_id = pok_current_partition;
   
 #ifdef POK_NEEDS_DEBUG
-  printf("BusFault in partition %d at address 0x%x\n", 
-         partition_id, fault_addr);
-  printf("PC: 0x%x, LR: 0x%x\n", frame[6], frame[5]);
+  if (cfsr & CFSR_BFARVALID) {
+    printf("BusFault in partition %d at address 0x%x\n", 
+           partition_id, fault_addr);
+  } else {
+    printf("BusFault in partition %d (address not available)\n", 
+           partition_id);
+  }
+  printf("PC: 0x%x, LR: 0x%x, CFSR: 0x%x\n", frame[6], frame[5], cfsr);
 #endif
   
   if (partition_id < POK_CONFIG_NB_PARTITIONS) {

--- a/kernel/arch/arm/exceptions.c
+++ b/kernel/arch/arm/exceptions.c
@@ -18,16 +18,16 @@
  * \brief   ARM Cortex-M exception handling
  */
 
-#include "nvic.h"
 #include "mpu.h"
+#include "nvic.h"
 #include <core/debug.h>
 #include <core/partition.h>
 #include <errno.h>
 
 /* CFSR (Configurable Fault Status Register) bits */
-#define SCB_CFSR    (*((volatile uint32_t *)(SCB_BASE + 0x28)))
-#define CFSR_MMARVALID  (1 << 7)   /* MemManage Fault Address Register valid */
-#define CFSR_BFARVALID  (1 << 15)  /* Bus Fault Address Register valid */
+#define SCB_CFSR (*((volatile uint32_t *)(SCB_BASE + 0x28)))
+#define CFSR_MMARVALID (1 << 7)  /* MemManage Fault Address Register valid */
+#define CFSR_BFARVALID (1 << 15) /* Bus Fault Address Register valid */
 
 /* Forward declarations for the actual handlers */
 static void MemManage_Handler_C(uint32_t *frame);
@@ -40,14 +40,14 @@ static void HardFault_Handler_C(uint32_t *frame);
  * Determines correct stack pointer (MSP vs PSP) based on EXC_RETURN
  */
 void __attribute__((naked)) MemManage_Handler(void) {
-  __asm volatile (
-    "tst lr, #4                 \n"  /* Test EXC_RETURN[2] */
-    "ite eq                     \n"  /* If-Then-Else */
-    "mrseq r0, msp              \n"  /* If EXC_RETURN[2]==0, use MSP */
-    "mrsne r0, psp              \n"  /* If EXC_RETURN[2]==1, use PSP */
-    "b MemManage_Handler_C      \n"  /* Call C handler with correct frame */
-    ::: "r0", "memory"
-  );
+  __asm volatile(
+      "tst lr, #4                 \n" /* Test EXC_RETURN[2] */
+      "ite eq                     \n" /* If-Then-Else */
+      "mrseq r0, msp              \n" /* If EXC_RETURN[2]==0, use MSP */
+      "mrsne r0, psp              \n" /* If EXC_RETURN[2]==1, use PSP */
+      "b MemManage_Handler_C      \n" /* Call C handler with correct frame */
+      ::
+          : "r0", "memory");
 }
 
 /*
@@ -58,52 +58,52 @@ static void MemManage_Handler_C(uint32_t *frame) {
   uint32_t fault_addr = 0;
   uint8_t partition_id;
   uint32_t cfsr;
-  
+
   if (frame == NULL) {
     /* Cannot recover from null frame, halt system */
     while (1) {
-      __asm volatile ("wfi");
+      __asm volatile("wfi");
     }
   }
-  
+
   /* Read CFSR to check fault status */
   cfsr = SCB_CFSR;
-  
+
   /* Get faulting address from MemManage Fault Address Register if valid */
   if (cfsr & CFSR_MMARVALID) {
     fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x34)); /* MMFAR */
   }
-  
+
   /* Clear MemManage fault flags in CFSR */
-  SCB_CFSR = cfsr & 0xFF;  /* Clear MMFSR bits */
-  
+  SCB_CFSR = cfsr & 0xFF; /* Clear MMFSR bits */
+
   /* Get current partition */
   extern uint8_t pok_current_partition;
   partition_id = pok_current_partition;
-  
+
 #ifdef POK_NEEDS_DEBUG
   if (cfsr & CFSR_MMARVALID) {
-    printf("MemManage fault in partition %d at address 0x%x\n", 
-           partition_id, fault_addr);
+    printf("MemManage fault in partition %d at address 0x%x\n", partition_id,
+           fault_addr);
   } else {
-    printf("MemManage fault in partition %d (address not available)\n", 
+    printf("MemManage fault in partition %d (address not available)\n",
            partition_id);
   }
   printf("PC: 0x%x, LR: 0x%x, CFSR: 0x%x\n", frame[6], frame[5], cfsr);
 #endif
-  
+
   /* Handle partition isolation violation */
   if (partition_id < POK_CONFIG_NB_PARTITIONS) {
     /* Terminate the offending partition */
     pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
-    
+
     /* Force a reschedule to switch away from this partition */
     pok_sched_end_period();
   }
-  
+
   /* If we reach here, halt the system */
   while (1) {
-    __asm volatile ("wfi");
+    __asm volatile("wfi");
   }
 }
 
@@ -112,14 +112,14 @@ static void MemManage_Handler_C(uint32_t *frame) {
  * Determines correct stack pointer (MSP vs PSP) based on EXC_RETURN
  */
 void __attribute__((naked)) BusFault_Handler(void) {
-  __asm volatile (
-    "tst lr, #4                 \n"  /* Test EXC_RETURN[2] */
-    "ite eq                     \n"  /* If-Then-Else */
-    "mrseq r0, msp              \n"  /* If EXC_RETURN[2]==0, use MSP */
-    "mrsne r0, psp              \n"  /* If EXC_RETURN[2]==1, use PSP */
-    "b BusFault_Handler_C       \n"  /* Call C handler with correct frame */
-    ::: "r0", "memory"
-  );
+  __asm volatile(
+      "tst lr, #4                 \n" /* Test EXC_RETURN[2] */
+      "ite eq                     \n" /* If-Then-Else */
+      "mrseq r0, msp              \n" /* If EXC_RETURN[2]==0, use MSP */
+      "mrsne r0, psp              \n" /* If EXC_RETURN[2]==1, use PSP */
+      "b BusFault_Handler_C       \n" /* Call C handler with correct frame */
+      ::
+          : "r0", "memory");
 }
 
 /*
@@ -130,61 +130,60 @@ static void BusFault_Handler_C(uint32_t *frame) {
   uint32_t fault_addr = 0;
   uint8_t partition_id;
   uint32_t cfsr;
-  
+
   if (frame == NULL) {
     while (1) {
-      __asm volatile ("wfi");
+      __asm volatile("wfi");
     }
   }
-  
+
   /* Read CFSR to check fault status */
   cfsr = SCB_CFSR;
-  
+
   /* Get faulting address from Bus Fault Address Register if valid */
   if (cfsr & CFSR_BFARVALID) {
     fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x38)); /* BFAR */
   }
-  
+
   /* Clear Bus fault flags in CFSR */
-  SCB_CFSR = (cfsr & 0xFF00) >> 8;  /* Clear BFSR bits */
-  
+  SCB_CFSR = (cfsr & 0xFF00) >> 8; /* Clear BFSR bits */
+
   extern uint8_t pok_current_partition;
   partition_id = pok_current_partition;
-  
+
 #ifdef POK_NEEDS_DEBUG
   if (cfsr & CFSR_BFARVALID) {
-    printf("BusFault in partition %d at address 0x%x\n", 
-           partition_id, fault_addr);
+    printf("BusFault in partition %d at address 0x%x\n", partition_id,
+           fault_addr);
   } else {
-    printf("BusFault in partition %d (address not available)\n", 
-           partition_id);
+    printf("BusFault in partition %d (address not available)\n", partition_id);
   }
   printf("PC: 0x%x, LR: 0x%x, CFSR: 0x%x\n", frame[6], frame[5], cfsr);
 #endif
-  
+
   if (partition_id < POK_CONFIG_NB_PARTITIONS) {
     pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
     pok_sched_end_period();
   }
-  
+
   while (1) {
-    __asm volatile ("wfi");
+    __asm volatile("wfi");
   }
 }
 
 /*
- * Usage Fault Handler - Naked wrapper  
+ * Usage Fault Handler - Naked wrapper
  * Determines correct stack pointer (MSP vs PSP) based on EXC_RETURN
  */
 void __attribute__((naked)) UsageFault_Handler(void) {
-  __asm volatile (
-    "tst lr, #4                 \n"  /* Test EXC_RETURN[2] */
-    "ite eq                     \n"  /* If-Then-Else */
-    "mrseq r0, msp              \n"  /* If EXC_RETURN[2]==0, use MSP */
-    "mrsne r0, psp              \n"  /* If EXC_RETURN[2]==1, use PSP */
-    "b UsageFault_Handler_C     \n"  /* Call C handler with correct frame */
-    ::: "r0", "memory"
-  );
+  __asm volatile(
+      "tst lr, #4                 \n" /* Test EXC_RETURN[2] */
+      "ite eq                     \n" /* If-Then-Else */
+      "mrseq r0, msp              \n" /* If EXC_RETURN[2]==0, use MSP */
+      "mrsne r0, psp              \n" /* If EXC_RETURN[2]==1, use PSP */
+      "b UsageFault_Handler_C     \n" /* Call C handler with correct frame */
+      ::
+          : "r0", "memory");
 }
 
 /*
@@ -193,28 +192,28 @@ void __attribute__((naked)) UsageFault_Handler(void) {
  */
 static void UsageFault_Handler_C(uint32_t *frame) {
   uint8_t partition_id;
-  
+
   if (frame == NULL) {
     while (1) {
-      __asm volatile ("wfi");
+      __asm volatile("wfi");
     }
   }
-  
+
   extern uint8_t pok_current_partition;
   partition_id = pok_current_partition;
-  
+
 #ifdef POK_NEEDS_DEBUG
   printf("UsageFault in partition %d\n", partition_id);
   printf("PC: 0x%x, LR: 0x%x\n", frame[6], frame[5]);
 #endif
-  
+
   if (partition_id < POK_CONFIG_NB_PARTITIONS) {
     pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
     pok_sched_end_period();
   }
-  
+
   while (1) {
-    __asm volatile ("wfi");
+    __asm volatile("wfi");
   }
 }
 
@@ -227,14 +226,14 @@ static void UsageFault_Handler_C(uint32_t *frame) {
  * Determines correct stack pointer (MSP vs PSP) based on EXC_RETURN
  */
 void __attribute__((naked)) HardFault_Handler(void) {
-  __asm volatile (
-    "tst lr, #4                 \n"  /* Test EXC_RETURN[2] */
-    "ite eq                     \n"  /* If-Then-Else */
-    "mrseq r0, msp              \n"  /* If EXC_RETURN[2]==0, use MSP */
-    "mrsne r0, psp              \n"  /* If EXC_RETURN[2]==1, use PSP */
-    "b HardFault_Handler_C      \n"  /* Call C handler with correct frame */
-    ::: "r0", "memory"
-  );
+  __asm volatile(
+      "tst lr, #4                 \n" /* Test EXC_RETURN[2] */
+      "ite eq                     \n" /* If-Then-Else */
+      "mrseq r0, msp              \n" /* If EXC_RETURN[2]==0, use MSP */
+      "mrsne r0, psp              \n" /* If EXC_RETURN[2]==1, use PSP */
+      "b HardFault_Handler_C      \n" /* Call C handler with correct frame */
+      ::
+          : "r0", "memory");
 }
 
 /*
@@ -242,31 +241,31 @@ void __attribute__((naked)) HardFault_Handler(void) {
  */
 static void HardFault_Handler_C(uint32_t *frame) {
   uint8_t partition_id;
-  
+
   if (frame == NULL) {
     while (1) {
-      __asm volatile ("wfi");
+      __asm volatile("wfi");
     }
   }
-  
+
   extern uint8_t pok_current_partition;
   partition_id = pok_current_partition;
-  
+
 #ifdef POK_NEEDS_DEBUG
   printf("HardFault in partition %d\n", partition_id);
   printf("PC: 0x%x, LR: 0x%x, PSR: 0x%x\n", frame[6], frame[5], frame[7]);
-  printf("r0: 0x%x, r1: 0x%x, r2: 0x%x, r3: 0x%x\n", 
-         frame[0], frame[1], frame[2], frame[3]);
+  printf("r0: 0x%x, r1: 0x%x, r2: 0x%x, r3: 0x%x\n", frame[0], frame[1],
+         frame[2], frame[3]);
 #endif
-  
+
   /* Try to recover by stopping the current partition */
   if (partition_id < POK_CONFIG_NB_PARTITIONS) {
     pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
     pok_sched_end_period();
   }
-  
+
   /* If recovery fails, halt the system */
   while (1) {
-    __asm volatile ("wfi");
+    __asm volatile("wfi");
   }
 }

--- a/kernel/arch/arm/exceptions.c
+++ b/kernel/arch/arm/exceptions.c
@@ -42,6 +42,13 @@ void MemManage_Handler(void) {
   /* Get stack frame */
   __asm volatile ("mrs %0, psp" : "=r" (frame));
   
+  if (frame == NULL) {
+    /* Cannot recover from null frame, halt system */
+    while (1) {
+      __asm volatile ("wfi");
+    }
+  }
+  
   /* Read CFSR to check fault status */
   cfsr = SCB_CFSR;
   
@@ -74,7 +81,7 @@ void MemManage_Handler(void) {
     pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
     
     /* Force a reschedule to switch away from this partition */
-    pok_sched();
+    pok_sched_end_period();
   }
   
   /* If we reach here, halt the system */
@@ -94,6 +101,12 @@ void BusFault_Handler(void) {
   uint32_t cfsr;
   
   __asm volatile ("mrs %0, psp" : "=r" (frame));
+  
+  if (frame == NULL) {
+    while (1) {
+      __asm volatile ("wfi");
+    }
+  }
   
   /* Read CFSR to check fault status */
   cfsr = SCB_CFSR;
@@ -122,7 +135,7 @@ void BusFault_Handler(void) {
   
   if (partition_id < POK_CONFIG_NB_PARTITIONS) {
     pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
-    pok_sched();
+    pok_sched_end_period();
   }
   
   while (1) {
@@ -140,6 +153,12 @@ void UsageFault_Handler(void) {
   
   __asm volatile ("mrs %0, psp" : "=r" (frame));
   
+  if (frame == NULL) {
+    while (1) {
+      __asm volatile ("wfi");
+    }
+  }
+  
   extern uint8_t pok_current_partition;
   partition_id = pok_current_partition;
   
@@ -150,7 +169,7 @@ void UsageFault_Handler(void) {
   
   if (partition_id < POK_CONFIG_NB_PARTITIONS) {
     pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
-    pok_sched();
+    pok_sched_end_period();
   }
   
   while (1) {
@@ -168,6 +187,12 @@ void HardFault_Handler(void) {
   
   __asm volatile ("mrs %0, psp" : "=r" (frame));
   
+  if (frame == NULL) {
+    while (1) {
+      __asm volatile ("wfi");
+    }
+  }
+  
   extern uint8_t pok_current_partition;
   partition_id = pok_current_partition;
   
@@ -181,7 +206,7 @@ void HardFault_Handler(void) {
   /* Try to recover by stopping the current partition */
   if (partition_id < POK_CONFIG_NB_PARTITIONS) {
     pok_partition_set_mode(partition_id, POK_PARTITION_MODE_STOPPED);
-    pok_sched();
+    pok_sched_end_period();
   }
   
   /* If recovery fails, halt the system */

--- a/kernel/arch/arm/exceptions.c
+++ b/kernel/arch/arm/exceptions.c
@@ -29,18 +29,35 @@
 #define CFSR_MMARVALID  (1 << 7)   /* MemManage Fault Address Register valid */
 #define CFSR_BFARVALID  (1 << 15)  /* Bus Fault Address Register valid */
 
+/* Forward declarations for the actual handlers */
+static void MemManage_Handler_C(uint32_t *frame);
+static void BusFault_Handler_C(uint32_t *frame);
+static void UsageFault_Handler_C(uint32_t *frame);
+static void HardFault_Handler_C(uint32_t *frame);
+
 /*
- * Memory Management Fault Handler
+ * Memory Management Fault Handler - Naked wrapper
+ * Determines correct stack pointer (MSP vs PSP) based on EXC_RETURN
+ */
+void __attribute__((naked)) MemManage_Handler(void) {
+  __asm volatile (
+    "tst lr, #4                 \n"  /* Test EXC_RETURN[2] */
+    "ite eq                     \n"  /* If-Then-Else */
+    "mrseq r0, msp              \n"  /* If EXC_RETURN[2]==0, use MSP */
+    "mrsne r0, psp              \n"  /* If EXC_RETURN[2]==1, use PSP */
+    "b MemManage_Handler_C      \n"  /* Call C handler with correct frame */
+    ::: "r0", "memory"
+  );
+}
+
+/*
+ * Memory Management Fault Handler - C implementation
  * Handles MPU violations and other memory management faults
  */
-void MemManage_Handler(void) {
-  uint32_t *frame;
+static void MemManage_Handler_C(uint32_t *frame) {
   uint32_t fault_addr = 0;
   uint8_t partition_id;
   uint32_t cfsr;
-  
-  /* Get stack frame */
-  __asm volatile ("mrs %0, psp" : "=r" (frame));
   
   if (frame == NULL) {
     /* Cannot recover from null frame, halt system */
@@ -91,16 +108,28 @@ void MemManage_Handler(void) {
 }
 
 /*
- * Bus Fault Handler
+ * Bus Fault Handler - Naked wrapper
+ * Determines correct stack pointer (MSP vs PSP) based on EXC_RETURN
+ */
+void __attribute__((naked)) BusFault_Handler(void) {
+  __asm volatile (
+    "tst lr, #4                 \n"  /* Test EXC_RETURN[2] */
+    "ite eq                     \n"  /* If-Then-Else */
+    "mrseq r0, msp              \n"  /* If EXC_RETURN[2]==0, use MSP */
+    "mrsne r0, psp              \n"  /* If EXC_RETURN[2]==1, use PSP */
+    "b BusFault_Handler_C       \n"  /* Call C handler with correct frame */
+    ::: "r0", "memory"
+  );
+}
+
+/*
+ * Bus Fault Handler - C implementation
  * Handles bus errors and invalid memory accesses
  */
-void BusFault_Handler(void) {
-  uint32_t *frame;
+static void BusFault_Handler_C(uint32_t *frame) {
   uint32_t fault_addr = 0;
   uint8_t partition_id;
   uint32_t cfsr;
-  
-  __asm volatile ("mrs %0, psp" : "=r" (frame));
   
   if (frame == NULL) {
     while (1) {
@@ -144,14 +173,26 @@ void BusFault_Handler(void) {
 }
 
 /*
- * Usage Fault Handler  
+ * Usage Fault Handler - Naked wrapper  
+ * Determines correct stack pointer (MSP vs PSP) based on EXC_RETURN
+ */
+void __attribute__((naked)) UsageFault_Handler(void) {
+  __asm volatile (
+    "tst lr, #4                 \n"  /* Test EXC_RETURN[2] */
+    "ite eq                     \n"  /* If-Then-Else */
+    "mrseq r0, msp              \n"  /* If EXC_RETURN[2]==0, use MSP */
+    "mrsne r0, psp              \n"  /* If EXC_RETURN[2]==1, use PSP */
+    "b UsageFault_Handler_C     \n"  /* Call C handler with correct frame */
+    ::: "r0", "memory"
+  );
+}
+
+/*
+ * Usage Fault Handler - C implementation
  * Handles undefined instruction, unaligned access, etc.
  */
-void UsageFault_Handler(void) {
-  uint32_t *frame;
+static void UsageFault_Handler_C(uint32_t *frame) {
   uint8_t partition_id;
-  
-  __asm volatile ("mrs %0, psp" : "=r" (frame));
   
   if (frame == NULL) {
     while (1) {
@@ -181,11 +222,26 @@ void UsageFault_Handler(void) {
  * Hard Fault Handler
  * Last resort fault handler
  */
-void HardFault_Handler(void) {
-  uint32_t *frame;
+/*
+ * Hard Fault Handler - Naked wrapper
+ * Determines correct stack pointer (MSP vs PSP) based on EXC_RETURN
+ */
+void __attribute__((naked)) HardFault_Handler(void) {
+  __asm volatile (
+    "tst lr, #4                 \n"  /* Test EXC_RETURN[2] */
+    "ite eq                     \n"  /* If-Then-Else */
+    "mrseq r0, msp              \n"  /* If EXC_RETURN[2]==0, use MSP */
+    "mrsne r0, psp              \n"  /* If EXC_RETURN[2]==1, use PSP */
+    "b HardFault_Handler_C      \n"  /* Call C handler with correct frame */
+    ::: "r0", "memory"
+  );
+}
+
+/*
+ * Hard Fault Handler - C implementation
+ */
+static void HardFault_Handler_C(uint32_t *frame) {
   uint8_t partition_id;
-  
-  __asm volatile ("mrs %0, psp" : "=r" (frame));
   
   if (frame == NULL) {
     while (1) {

--- a/kernel/arch/arm/mpu.c
+++ b/kernel/arch/arm/mpu.c
@@ -25,6 +25,12 @@
 static uint8_t mpu_region_count = 0;
 static mpu_region_t mpu_regions[MPU_MAX_REGIONS];
 
+/**
+ * Initialize the Memory Protection Unit (MPU)
+ * Detects available MPU regions and sets up initial configuration
+ * 
+ * @return POK_ERRNO_OK on success, POK_ERRNO_UNAVAILABLE if no MPU present
+ */
 pok_ret_t pok_mpu_init(void) {
   uint32_t mpu_type;
   
@@ -57,6 +63,15 @@ pok_ret_t pok_mpu_init(void) {
   return (POK_ERRNO_OK);
 }
 
+/**
+ * Configure an MPU region with specified protection attributes
+ * 
+ * @param region MPU region number (0-7 typically)
+ * @param base_addr Base address of the region (must be aligned to size)
+ * @param size Size of the region (must be power of 2, minimum 32 bytes)
+ * @param attributes Access permissions and memory attributes
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
 pok_ret_t pok_mpu_configure_region(uint8_t region, uint32_t base_addr, 
                                    uint32_t size, uint32_t attributes) {
   uint32_t rasr;
@@ -145,8 +160,8 @@ pok_ret_t pok_mpu_disable(void) {
   return (POK_ERRNO_OK);
 }
 
-uint8_t pok_mpu_get_region_count(void) {
-  return mpu_region_count;
+inline uint8_t pok_mpu_get_region_count(void) {
+  return (mpu_region_count);
 }
 
 uint32_t pok_mpu_size_to_rasr(uint32_t size) {
@@ -154,7 +169,7 @@ uint32_t pok_mpu_size_to_rasr(uint32_t size) {
   
   /* Size must be power of 2 and >= 32 bytes */
   if (size < 32 || (size & (size - 1)) != 0) {
-    return 0; /* Invalid size */
+    return (0); /* Invalid size */
   }
   
   /* Calculate size field (log2(size) - 1) */

--- a/kernel/arch/arm/mpu.c
+++ b/kernel/arch/arm/mpu.c
@@ -1,0 +1,168 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/mpu.c
+ * \author  POK team
+ * \brief   ARM Cortex-M MPU (Memory Protection Unit) implementation
+ */
+
+#include "mpu.h"
+#include <errno.h>
+#include <libc.h>
+
+static uint8_t mpu_region_count = 0;
+static mpu_region_t mpu_regions[MPU_MAX_REGIONS];
+
+pok_ret_t pok_mpu_init(void) {
+  uint32_t mpu_type;
+  
+  /* Read MPU Type register to get number of regions */
+  mpu_type = MPU_TYPE;
+  mpu_region_count = (mpu_type >> 8) & 0xFF;
+  
+  if (mpu_region_count == 0) {
+    /* No MPU present */
+    return (POK_ERRNO_UNAVAILABLE);
+  }
+  
+  if (mpu_region_count > MPU_MAX_REGIONS) {
+    mpu_region_count = MPU_MAX_REGIONS;
+  }
+  
+  /* Disable MPU during configuration */
+  pok_mpu_disable();
+  
+  /* Clear all regions */
+  memset(mpu_regions, 0, sizeof(mpu_regions));
+  
+  for (uint8_t i = 0; i < mpu_region_count; i++) {
+    pok_mpu_disable_region(i);
+  }
+  
+  /* Enable MPU with default memory map for privileged access */
+  pok_mpu_enable();
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_mpu_configure_region(uint8_t region, uint32_t base_addr, 
+                                   uint32_t size, uint32_t attributes) {
+  uint32_t rasr;
+  
+  if (region >= mpu_region_count) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  /* Ensure base address is aligned to size */
+  if ((base_addr & (size - 1)) != 0) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  /* Select region */
+  MPU_RNR = region;
+  
+  /* Configure base address */
+  MPU_RBAR = base_addr | MPU_RBAR_VALID | region;
+  
+  /* Configure attributes and size */
+  rasr = pok_mpu_size_to_rasr(size) | attributes | MPU_RASR_ENABLE;
+  MPU_RASR = rasr;
+  
+  /* Store configuration */
+  mpu_regions[region].base_addr = base_addr;
+  mpu_regions[region].size = size;
+  mpu_regions[region].attributes = attributes;
+  mpu_regions[region].region_id = region;
+  mpu_regions[region].enabled = 1;
+  
+  /* Data Synchronization Barrier */
+  __asm volatile ("dsb" : : : "memory");
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_mpu_enable_region(uint8_t region) {
+  if (region >= mpu_region_count) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  if (!mpu_regions[region].enabled) {
+    MPU_RNR = region;
+    MPU_RASR |= MPU_RASR_ENABLE;
+    mpu_regions[region].enabled = 1;
+    
+    __asm volatile ("dsb" : : : "memory");
+  }
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_mpu_disable_region(uint8_t region) {
+  if (region >= mpu_region_count) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  MPU_RNR = region;
+  MPU_RASR &= ~MPU_RASR_ENABLE;
+  mpu_regions[region].enabled = 0;
+  
+  __asm volatile ("dsb" : : : "memory");
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_mpu_enable(void) {
+  /* Enable MPU with background region for privileged access */
+  MPU_CTRL = MPU_CTRL_ENABLE | MPU_CTRL_PRIVDEFENA;
+  
+  /* Data Synchronization Barrier */
+  __asm volatile ("dsb" : : : "memory");
+  /* Instruction Synchronization Barrier */
+  __asm volatile ("isb" : : : "memory");
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_mpu_disable(void) {
+  /* Disable MPU */
+  MPU_CTRL = 0;
+  
+  __asm volatile ("dsb" : : : "memory");
+  __asm volatile ("isb" : : : "memory");
+  
+  return (POK_ERRNO_OK);
+}
+
+uint8_t pok_mpu_get_region_count(void) {
+  return mpu_region_count;
+}
+
+uint32_t pok_mpu_size_to_rasr(uint32_t size) {
+  uint32_t rasr_size = 0;
+  
+  /* Size must be power of 2 and >= 32 bytes */
+  if (size < 32 || (size & (size - 1)) != 0) {
+    return 0; /* Invalid size */
+  }
+  
+  /* Calculate size field (log2(size) - 1) */
+  while (size > 1) {
+    size >>= 1;
+    rasr_size++;
+  }
+  rasr_size--;
+  
+  return (rasr_size << MPU_RASR_SIZE_SHIFT) & MPU_RASR_SIZE_MASK;
+}

--- a/kernel/arch/arm/mpu.c
+++ b/kernel/arch/arm/mpu.c
@@ -28,83 +28,83 @@ static mpu_region_t mpu_regions[MPU_MAX_REGIONS];
 /**
  * Initialize the Memory Protection Unit (MPU)
  * Detects available MPU regions and sets up initial configuration
- * 
+ *
  * @return POK_ERRNO_OK on success, POK_ERRNO_UNAVAILABLE if no MPU present
  */
 pok_ret_t pok_mpu_init(void) {
   uint32_t mpu_type;
-  
+
   /* Read MPU Type register to get number of regions */
   mpu_type = MPU_TYPE;
   mpu_region_count = (mpu_type >> 8) & 0xFF;
-  
+
   if (mpu_region_count == 0) {
     /* No MPU present */
     return (POK_ERRNO_UNAVAILABLE);
   }
-  
+
   if (mpu_region_count > MPU_MAX_REGIONS) {
     mpu_region_count = MPU_MAX_REGIONS;
   }
-  
+
   /* Disable MPU during configuration */
   pok_mpu_disable();
-  
+
   /* Clear all regions */
   memset(mpu_regions, 0, sizeof(mpu_regions));
-  
+
   for (uint8_t i = 0; i < mpu_region_count; i++) {
     pok_mpu_disable_region(i);
   }
-  
+
   /* Enable MPU with default memory map for privileged access */
   pok_mpu_enable();
-  
+
   return (POK_ERRNO_OK);
 }
 
 /**
  * Configure an MPU region with specified protection attributes
- * 
+ *
  * @param region MPU region number (0-7 typically)
  * @param base_addr Base address of the region (must be aligned to size)
  * @param size Size of the region (must be power of 2, minimum 32 bytes)
  * @param attributes Access permissions and memory attributes
  * @return POK_ERRNO_OK on success, error code on failure
  */
-pok_ret_t pok_mpu_configure_region(uint8_t region, uint32_t base_addr, 
+pok_ret_t pok_mpu_configure_region(uint8_t region, uint32_t base_addr,
                                    uint32_t size, uint32_t attributes) {
   uint32_t rasr;
-  
+
   if (region >= mpu_region_count) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   /* Ensure base address is aligned to size */
   if ((base_addr & (size - 1)) != 0) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   /* Select region */
   MPU_RNR = region;
-  
+
   /* Configure base address */
   MPU_RBAR = base_addr | MPU_RBAR_VALID | region;
-  
+
   /* Configure attributes and size */
   rasr = pok_mpu_size_to_rasr(size) | attributes | MPU_RASR_ENABLE;
   MPU_RASR = rasr;
-  
+
   /* Store configuration */
   mpu_regions[region].base_addr = base_addr;
   mpu_regions[region].size = size;
   mpu_regions[region].attributes = attributes;
   mpu_regions[region].region_id = region;
   mpu_regions[region].enabled = 1;
-  
+
   /* Data Synchronization Barrier */
-  __asm volatile ("dsb" : : : "memory");
-  
+  __asm volatile("dsb" : : : "memory");
+
   return (POK_ERRNO_OK);
 }
 
@@ -112,15 +112,15 @@ pok_ret_t pok_mpu_enable_region(uint8_t region) {
   if (region >= mpu_region_count) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   if (!mpu_regions[region].enabled) {
     MPU_RNR = region;
     MPU_RASR |= MPU_RASR_ENABLE;
     mpu_regions[region].enabled = 1;
-    
-    __asm volatile ("dsb" : : : "memory");
+
+    __asm volatile("dsb" : : : "memory");
   }
-  
+
   return (POK_ERRNO_OK);
 }
 
@@ -128,56 +128,54 @@ pok_ret_t pok_mpu_disable_region(uint8_t region) {
   if (region >= mpu_region_count) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   MPU_RNR = region;
   MPU_RASR &= ~MPU_RASR_ENABLE;
   mpu_regions[region].enabled = 0;
-  
-  __asm volatile ("dsb" : : : "memory");
-  
+
+  __asm volatile("dsb" : : : "memory");
+
   return (POK_ERRNO_OK);
 }
 
 pok_ret_t pok_mpu_enable(void) {
   /* Enable MPU with background region for privileged access */
   MPU_CTRL = MPU_CTRL_ENABLE | MPU_CTRL_PRIVDEFENA;
-  
+
   /* Data Synchronization Barrier */
-  __asm volatile ("dsb" : : : "memory");
+  __asm volatile("dsb" : : : "memory");
   /* Instruction Synchronization Barrier */
-  __asm volatile ("isb" : : : "memory");
-  
+  __asm volatile("isb" : : : "memory");
+
   return (POK_ERRNO_OK);
 }
 
 pok_ret_t pok_mpu_disable(void) {
   /* Disable MPU */
   MPU_CTRL = 0;
-  
-  __asm volatile ("dsb" : : : "memory");
-  __asm volatile ("isb" : : : "memory");
-  
+
+  __asm volatile("dsb" : : : "memory");
+  __asm volatile("isb" : : : "memory");
+
   return (POK_ERRNO_OK);
 }
 
-inline uint8_t pok_mpu_get_region_count(void) {
-  return (mpu_region_count);
-}
+inline uint8_t pok_mpu_get_region_count(void) { return (mpu_region_count); }
 
 uint32_t pok_mpu_size_to_rasr(uint32_t size) {
   uint32_t rasr_size = 0;
-  
+
   /* Size must be power of 2 and >= 32 bytes */
   if (size < 32 || (size & (size - 1)) != 0) {
     return (0); /* Invalid size */
   }
-  
+
   /* Calculate size field (log2(size) - 1) */
   while (size > 1) {
     size >>= 1;
     rasr_size++;
   }
   rasr_size--;
-  
+
   return (rasr_size << MPU_RASR_SIZE_SHIFT) & MPU_RASR_SIZE_MASK;
 }

--- a/kernel/arch/arm/mpu.h
+++ b/kernel/arch/arm/mpu.h
@@ -1,0 +1,91 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_MPU_H__
+#define __POK_ARM_MPU_H__
+
+#include <types.h>
+#include <errno.h>
+
+/* ARM Cortex-M MPU Register Base */
+#define MPU_BASE                0xE000ED90
+
+/* MPU Registers */
+#define MPU_TYPE                (*((volatile uint32_t *)(MPU_BASE + 0x00)))
+#define MPU_CTRL                (*((volatile uint32_t *)(MPU_BASE + 0x04)))
+#define MPU_RNR                 (*((volatile uint32_t *)(MPU_BASE + 0x08)))
+#define MPU_RBAR                (*((volatile uint32_t *)(MPU_BASE + 0x0C)))
+#define MPU_RASR                (*((volatile uint32_t *)(MPU_BASE + 0x10)))
+
+/* MPU Control Register bits */
+#define MPU_CTRL_ENABLE         (1 << 0)
+#define MPU_CTRL_HFNMIENA       (1 << 1)
+#define MPU_CTRL_PRIVDEFENA     (1 << 2)
+
+/* MPU Region Base Address Register bits */
+#define MPU_RBAR_VALID          (1 << 4)
+#define MPU_RBAR_REGION_MASK    0x0F
+
+/* MPU Region Attribute and Size Register bits */
+#define MPU_RASR_ENABLE         (1 << 0)
+#define MPU_RASR_SIZE_SHIFT     1
+#define MPU_RASR_SIZE_MASK      (0x1F << MPU_RASR_SIZE_SHIFT)
+#define MPU_RASR_SRD_SHIFT      8
+#define MPU_RASR_SRD_MASK       (0xFF << MPU_RASR_SRD_SHIFT)
+#define MPU_RASR_B              (1 << 16)
+#define MPU_RASR_C              (1 << 17)
+#define MPU_RASR_S              (1 << 18)
+#define MPU_RASR_TEX_SHIFT      19
+#define MPU_RASR_TEX_MASK       (0x7 << MPU_RASR_TEX_SHIFT)
+#define MPU_RASR_AP_SHIFT       24
+#define MPU_RASR_AP_MASK        (0x7 << MPU_RASR_AP_SHIFT)
+#define MPU_RASR_XN             (1 << 28)
+
+/* Access Permission encoding */
+#define MPU_AP_NO_ACCESS        0x0
+#define MPU_AP_PRIV_RW          0x1
+#define MPU_AP_PRIV_RW_USER_RO  0x2
+#define MPU_AP_ALL_RW           0x3
+#define MPU_AP_PRIV_RO          0x5
+#define MPU_AP_ALL_RO           0x6
+
+/* Memory attributes */
+#define MPU_ATTR_NORMAL         (MPU_RASR_C | MPU_RASR_B)
+#define MPU_ATTR_DEVICE         0
+#define MPU_ATTR_STRONGLY_ORDERED 0
+
+/* Maximum number of MPU regions */
+#define MPU_MAX_REGIONS         8
+
+/* MPU region configuration structure */
+typedef struct {
+  uint32_t base_addr;
+  uint32_t size;
+  uint32_t attributes;
+  uint8_t  region_id;
+  uint8_t  enabled;
+} mpu_region_t;
+
+/* Function prototypes */
+pok_ret_t pok_mpu_init(void);
+pok_ret_t pok_mpu_configure_region(uint8_t region, uint32_t base_addr, 
+                                   uint32_t size, uint32_t attributes);
+pok_ret_t pok_mpu_enable_region(uint8_t region);
+pok_ret_t pok_mpu_disable_region(uint8_t region);
+pok_ret_t pok_mpu_enable(void);
+pok_ret_t pok_mpu_disable(void);
+uint8_t pok_mpu_get_region_count(void);
+uint32_t pok_mpu_size_to_rasr(uint32_t size);
+
+#endif /* !__POK_ARM_MPU_H__ */

--- a/kernel/arch/arm/mpu.h
+++ b/kernel/arch/arm/mpu.h
@@ -15,71 +15,71 @@
 #ifndef __POK_ARM_MPU_H__
 #define __POK_ARM_MPU_H__
 
-#include <types.h>
 #include <errno.h>
+#include <types.h>
 
 /* ARM Cortex-M MPU Register Base */
-#define MPU_BASE                0xE000ED90
+#define MPU_BASE 0xE000ED90
 
 /* MPU Registers */
-#define MPU_TYPE                (*((volatile uint32_t *)(MPU_BASE + 0x00)))
-#define MPU_CTRL                (*((volatile uint32_t *)(MPU_BASE + 0x04)))
-#define MPU_RNR                 (*((volatile uint32_t *)(MPU_BASE + 0x08)))
-#define MPU_RBAR                (*((volatile uint32_t *)(MPU_BASE + 0x0C)))
-#define MPU_RASR                (*((volatile uint32_t *)(MPU_BASE + 0x10)))
+#define MPU_TYPE (*((volatile uint32_t *)(MPU_BASE + 0x00)))
+#define MPU_CTRL (*((volatile uint32_t *)(MPU_BASE + 0x04)))
+#define MPU_RNR (*((volatile uint32_t *)(MPU_BASE + 0x08)))
+#define MPU_RBAR (*((volatile uint32_t *)(MPU_BASE + 0x0C)))
+#define MPU_RASR (*((volatile uint32_t *)(MPU_BASE + 0x10)))
 
 /* MPU Control Register bits */
-#define MPU_CTRL_ENABLE         (1 << 0)
-#define MPU_CTRL_HFNMIENA       (1 << 1)
-#define MPU_CTRL_PRIVDEFENA     (1 << 2)
+#define MPU_CTRL_ENABLE (1 << 0)
+#define MPU_CTRL_HFNMIENA (1 << 1)
+#define MPU_CTRL_PRIVDEFENA (1 << 2)
 
 /* MPU Region Base Address Register bits */
-#define MPU_RBAR_VALID          (1 << 4)
-#define MPU_RBAR_REGION_MASK    0x0F
+#define MPU_RBAR_VALID (1 << 4)
+#define MPU_RBAR_REGION_MASK 0x0F
 
 /* MPU Region Attribute and Size Register bits */
-#define MPU_RASR_ENABLE         (1 << 0)
-#define MPU_RASR_SIZE_SHIFT     1
-#define MPU_RASR_SIZE_MASK      (0x1F << MPU_RASR_SIZE_SHIFT)
-#define MPU_RASR_SRD_SHIFT      8
-#define MPU_RASR_SRD_MASK       (0xFF << MPU_RASR_SRD_SHIFT)
-#define MPU_RASR_B              (1 << 16)
-#define MPU_RASR_C              (1 << 17)
-#define MPU_RASR_S              (1 << 18)
-#define MPU_RASR_TEX_SHIFT      19
-#define MPU_RASR_TEX_MASK       (0x7 << MPU_RASR_TEX_SHIFT)
-#define MPU_RASR_AP_SHIFT       24
-#define MPU_RASR_AP_MASK        (0x7 << MPU_RASR_AP_SHIFT)
-#define MPU_RASR_XN             (1 << 28)
+#define MPU_RASR_ENABLE (1 << 0)
+#define MPU_RASR_SIZE_SHIFT 1
+#define MPU_RASR_SIZE_MASK (0x1F << MPU_RASR_SIZE_SHIFT)
+#define MPU_RASR_SRD_SHIFT 8
+#define MPU_RASR_SRD_MASK (0xFF << MPU_RASR_SRD_SHIFT)
+#define MPU_RASR_B (1 << 16)
+#define MPU_RASR_C (1 << 17)
+#define MPU_RASR_S (1 << 18)
+#define MPU_RASR_TEX_SHIFT 19
+#define MPU_RASR_TEX_MASK (0x7 << MPU_RASR_TEX_SHIFT)
+#define MPU_RASR_AP_SHIFT 24
+#define MPU_RASR_AP_MASK (0x7 << MPU_RASR_AP_SHIFT)
+#define MPU_RASR_XN (1 << 28)
 
 /* Access Permission encoding */
-#define MPU_AP_NO_ACCESS        0x0
-#define MPU_AP_PRIV_RW          0x1
-#define MPU_AP_PRIV_RW_USER_RO  0x2
-#define MPU_AP_ALL_RW           0x3
-#define MPU_AP_PRIV_RO          0x5
-#define MPU_AP_ALL_RO           0x6
+#define MPU_AP_NO_ACCESS 0x0
+#define MPU_AP_PRIV_RW 0x1
+#define MPU_AP_PRIV_RW_USER_RO 0x2
+#define MPU_AP_ALL_RW 0x3
+#define MPU_AP_PRIV_RO 0x5
+#define MPU_AP_ALL_RO 0x6
 
 /* Memory attributes */
-#define MPU_ATTR_NORMAL         (MPU_RASR_C | MPU_RASR_B)
-#define MPU_ATTR_DEVICE         0
+#define MPU_ATTR_NORMAL (MPU_RASR_C | MPU_RASR_B)
+#define MPU_ATTR_DEVICE 0
 #define MPU_ATTR_STRONGLY_ORDERED 0
 
 /* Maximum number of MPU regions */
-#define MPU_MAX_REGIONS         8
+#define MPU_MAX_REGIONS 8
 
 /* MPU region configuration structure */
 typedef struct {
   uint32_t base_addr;
   uint32_t size;
   uint32_t attributes;
-  uint8_t  region_id;
-  uint8_t  enabled;
+  uint8_t region_id;
+  uint8_t enabled;
 } mpu_region_t;
 
 /* Function prototypes */
 pok_ret_t pok_mpu_init(void);
-pok_ret_t pok_mpu_configure_region(uint8_t region, uint32_t base_addr, 
+pok_ret_t pok_mpu_configure_region(uint8_t region, uint32_t base_addr,
                                    uint32_t size, uint32_t attributes);
 pok_ret_t pok_mpu_enable_region(uint8_t region);
 pok_ret_t pok_mpu_disable_region(uint8_t region);

--- a/kernel/arch/arm/nvic.c
+++ b/kernel/arch/arm/nvic.c
@@ -15,7 +15,8 @@
 /**
  * \file    arch/arm/nvic.c
  * \author  POK team
- * \brief   ARM Cortex-M NVIC (Nested Vectored Interrupt Controller) implementation
+ * \brief   ARM Cortex-M NVIC (Nested Vectored Interrupt Controller)
+ * implementation
  */
 
 #include "nvic.h"
@@ -29,23 +30,24 @@ extern vector_table_entry_t vector_table[];
 static void pok_nvic_default_handler(void) {
   /* Default handler - infinite loop */
   while (1) {
-    __asm volatile ("wfi");
+    __asm volatile("wfi");
   }
 }
 
 pok_ret_t pok_nvic_init(void) {
   /* Enable memory management, bus fault, and usage fault exceptions */
-  SCB_SHCSR |= SCB_SHCSR_MEMFAULTENA | SCB_SHCSR_BUSFAULTENA | SCB_SHCSR_USGFAULTENA;
-  
+  SCB_SHCSR |=
+      SCB_SHCSR_MEMFAULTENA | SCB_SHCSR_BUSFAULTENA | SCB_SHCSR_USGFAULTENA;
+
   /* Set PendSV and SysTick to lowest priority for context switching */
   pok_nvic_set_priority(EXCEPTION_PENDSV, NVIC_PRIORITY_LOWEST);
   pok_nvic_set_priority(EXCEPTION_SYSTICK, NVIC_PRIORITY_LOWEST);
-  
+
   /* Clear all pending interrupts */
   for (int i = 0; i < 8; i++) {
     NVIC_ICPR[i] = 0xFFFFFFFF;
   }
-  
+
   return (POK_ERRNO_OK);
 }
 
@@ -53,14 +55,14 @@ pok_ret_t pok_nvic_set_handler(uint8_t irq, void (*handler)(void)) {
   if (irq >= NVIC_MAX_IRQ) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   /* Set handler in vector table */
   if (handler == NULL) {
     vector_table[irq] = pok_nvic_default_handler;
   } else {
     vector_table[irq] = handler;
   }
-  
+
   return (POK_ERRNO_OK);
 }
 
@@ -68,13 +70,13 @@ pok_ret_t pok_nvic_enable_irq(uint8_t irq) {
   if (irq < EXCEPTION_IRQ0 || irq >= NVIC_MAX_IRQ) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   uint8_t external_irq = irq - EXCEPTION_IRQ0;
   uint32_t reg_idx = external_irq / 32;
   uint32_t bit_pos = external_irq % 32;
-  
+
   NVIC_ISER[reg_idx] = (1 << bit_pos);
-  
+
   return (POK_ERRNO_OK);
 }
 
@@ -82,13 +84,13 @@ pok_ret_t pok_nvic_disable_irq(uint8_t irq) {
   if (irq < EXCEPTION_IRQ0 || irq >= NVIC_MAX_IRQ) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   uint8_t external_irq = irq - EXCEPTION_IRQ0;
   uint32_t reg_idx = external_irq / 32;
   uint32_t bit_pos = external_irq % 32;
-  
+
   NVIC_ICER[reg_idx] = (1 << bit_pos);
-  
+
   return (POK_ERRNO_OK);
 }
 
@@ -96,12 +98,12 @@ pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority) {
   if (irq >= NVIC_MAX_IRQ || priority > NVIC_PRIORITY_LOWEST) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   if (irq < EXCEPTION_IRQ0) {
     /* System exception priority */
     uint32_t *shpr_reg;
     uint8_t reg_offset;
-    
+
     if (irq >= 4 && irq <= 6) {
       /* MemManage (4), BusFault (5), UsageFault (6) */
       shpr_reg = (uint32_t *)&SCB_SHPR1;
@@ -109,24 +111,25 @@ pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority) {
     } else if (irq == 11) {
       /* SVCall (11) only */
       shpr_reg = (uint32_t *)&SCB_SHPR2;
-      reg_offset = 0;  /* SVCall is at bits [7:0] of SHPR2 */
+      reg_offset = 0; /* SVCall is at bits [7:0] of SHPR2 */
     } else if (irq == 12 || (irq >= 14 && irq <= 15)) {
       /* DebugMon (12), PendSV (14), SysTick (15) */
       shpr_reg = (uint32_t *)&SCB_SHPR3;
       if (irq == 12) {
-        reg_offset = 0;  /* DebugMon is at bits [7:0] of SHPR3 */
+        reg_offset = 0; /* DebugMon is at bits [7:0] of SHPR3 */
       } else {
-        reg_offset = (irq - 14) * 8 + 8;  /* PendSV at [15:8], SysTick at [23:16] */
+        reg_offset =
+            (irq - 14) * 8 + 8; /* PendSV at [15:8], SysTick at [23:16] */
       }
     } else {
       return (POK_ERRNO_EINVAL);
     }
-    
+
     /* Ensure offset doesn't exceed register bounds (24 bits max) */
     if (reg_offset > 24) {
       return (POK_ERRNO_EINVAL);
     }
-    
+
     uint32_t mask = ~(0xFFu << reg_offset);
     *shpr_reg = (*shpr_reg & mask) | ((priority << 4) << reg_offset);
   } else {
@@ -134,7 +137,7 @@ pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority) {
     uint8_t external_irq = irq - EXCEPTION_IRQ0;
     NVIC_IPR[external_irq] = priority << 4;
   }
-  
+
   return (POK_ERRNO_OK);
 }
 
@@ -142,13 +145,13 @@ pok_ret_t pok_nvic_clear_pending(uint8_t irq) {
   if (irq < EXCEPTION_IRQ0 || irq >= NVIC_MAX_IRQ) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   uint8_t external_irq = irq - EXCEPTION_IRQ0;
   uint32_t reg_idx = external_irq / 32;
   uint32_t bit_pos = external_irq % 32;
-  
+
   NVIC_ICPR[reg_idx] = (1 << bit_pos);
-  
+
   return (POK_ERRNO_OK);
 }
 
@@ -157,17 +160,13 @@ pok_ret_t pok_nvic_set_vector_table(uint32_t offset) {
   if (offset & 0x7F) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   SCB_VTOR = offset;
-  
+
   return (POK_ERRNO_OK);
 }
 
 /* Default exception handlers */
-void NMI_Handler(void) {
-  pok_nvic_default_handler();
-}
+void NMI_Handler(void) { pok_nvic_default_handler(); }
 
-void DebugMon_Handler(void) {
-  pok_nvic_default_handler();
-}
+void DebugMon_Handler(void) { pok_nvic_default_handler(); }

--- a/kernel/arch/arm/nvic.c
+++ b/kernel/arch/arm/nvic.c
@@ -26,7 +26,7 @@
 extern vector_table_entry_t vector_table[];
 
 /* Default handlers */
-static void default_handler(void) {
+static void pok_nvic_default_handler(void) {
   /* Default handler - infinite loop */
   while (1) {
     __asm volatile ("wfi");
@@ -56,7 +56,7 @@ pok_ret_t pok_nvic_set_handler(uint8_t irq, void (*handler)(void)) {
   
   /* Set handler in vector table */
   if (handler == NULL) {
-    vector_table[irq] = default_handler;
+    vector_table[irq] = pok_nvic_default_handler;
   } else {
     vector_table[irq] = handler;
   }
@@ -103,13 +103,13 @@ pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority) {
     uint8_t reg_offset;
     
     if (irq >= 4 && irq <= 6) {
-      shpr_reg = &SCB_SHPR1;
+      shpr_reg = (uint32_t *)&SCB_SHPR1;
       reg_offset = (irq - 4) * 8;
     } else if (irq >= 11 && irq <= 12) {
-      shpr_reg = &SCB_SHPR2;
+      shpr_reg = (uint32_t *)&SCB_SHPR2;
       reg_offset = (irq - 11) * 8;  /* Fixed: was (irq - 8) */
     } else if (irq >= 14 && irq <= 15) {
-      shpr_reg = &SCB_SHPR3;
+      shpr_reg = (uint32_t *)&SCB_SHPR3;
       reg_offset = (irq - 14) * 8;  /* Fixed: was (irq - 12) */
     } else {
       return (POK_ERRNO_EINVAL);
@@ -158,9 +158,9 @@ pok_ret_t pok_nvic_set_vector_table(uint32_t offset) {
 
 /* Default exception handlers */
 void NMI_Handler(void) {
-  default_handler();
+  pok_nvic_default_handler();
 }
 
 void DebugMon_Handler(void) {
-  default_handler();
+  pok_nvic_default_handler();
 }

--- a/kernel/arch/arm/nvic.c
+++ b/kernel/arch/arm/nvic.c
@@ -103,14 +103,21 @@ pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority) {
     uint8_t reg_offset;
     
     if (irq >= 4 && irq <= 6) {
+      /* MemManage (4), BusFault (5), UsageFault (6) */
       shpr_reg = (uint32_t *)&SCB_SHPR1;
       reg_offset = (irq - 4) * 8;
-    } else if (irq >= 11 && irq <= 12) {
+    } else if (irq == 11) {
+      /* SVCall (11) only */
       shpr_reg = (uint32_t *)&SCB_SHPR2;
-      reg_offset = (irq - 11) * 8;  /* Fixed: was (irq - 8) */
-    } else if (irq >= 14 && irq <= 15) {
+      reg_offset = 0;  /* SVCall is at bits [7:0] of SHPR2 */
+    } else if (irq == 12 || (irq >= 14 && irq <= 15)) {
+      /* DebugMon (12), PendSV (14), SysTick (15) */
       shpr_reg = (uint32_t *)&SCB_SHPR3;
-      reg_offset = (irq - 14) * 8;  /* Fixed: was (irq - 12) */
+      if (irq == 12) {
+        reg_offset = 0;  /* DebugMon is at bits [7:0] of SHPR3 */
+      } else {
+        reg_offset = (irq - 14) * 8 + 8;  /* PendSV at [15:8], SysTick at [23:16] */
+      }
     } else {
       return (POK_ERRNO_EINVAL);
     }

--- a/kernel/arch/arm/nvic.c
+++ b/kernel/arch/arm/nvic.c
@@ -1,0 +1,189 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/nvic.c
+ * \author  POK team
+ * \brief   ARM Cortex-M NVIC (Nested Vectored Interrupt Controller) implementation
+ */
+
+#include "nvic.h"
+#include <errno.h>
+#include <libc.h>
+
+/* External vector table (defined in startup code) */
+extern vector_table_entry_t vector_table[];
+
+/* Default handlers */
+static void default_handler(void) {
+  /* Default handler - infinite loop */
+  while (1) {
+    __asm volatile ("wfi");
+  }
+}
+
+pok_ret_t pok_nvic_init(void) {
+  /* Enable memory management, bus fault, and usage fault exceptions */
+  SCB_SHCSR |= SCB_SHCSR_MEMFAULTENA | SCB_SHCSR_BUSFAULTENA | SCB_SHCSR_USGFAULTENA;
+  
+  /* Set PendSV and SysTick to lowest priority for context switching */
+  pok_nvic_set_priority(EXCEPTION_PENDSV, NVIC_PRIORITY_LOWEST);
+  pok_nvic_set_priority(EXCEPTION_SYSTICK, NVIC_PRIORITY_LOWEST);
+  
+  /* Clear all pending interrupts */
+  for (int i = 0; i < 8; i++) {
+    NVIC_ICPR[i] = 0xFFFFFFFF;
+  }
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_nvic_set_handler(uint8_t irq, void (*handler)(void)) {
+  if (irq >= NVIC_MAX_IRQ) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  /* Set handler in vector table */
+  if (handler == NULL) {
+    vector_table[irq] = default_handler;
+  } else {
+    vector_table[irq] = handler;
+  }
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_nvic_enable_irq(uint8_t irq) {
+  if (irq < EXCEPTION_IRQ0 || irq >= NVIC_MAX_IRQ) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  uint8_t external_irq = irq - EXCEPTION_IRQ0;
+  uint32_t reg_idx = external_irq / 32;
+  uint32_t bit_pos = external_irq % 32;
+  
+  NVIC_ISER[reg_idx] = (1 << bit_pos);
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_nvic_disable_irq(uint8_t irq) {
+  if (irq < EXCEPTION_IRQ0 || irq >= NVIC_MAX_IRQ) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  uint8_t external_irq = irq - EXCEPTION_IRQ0;
+  uint32_t reg_idx = external_irq / 32;
+  uint32_t bit_pos = external_irq % 32;
+  
+  NVIC_ICER[reg_idx] = (1 << bit_pos);
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority) {
+  if (irq >= NVIC_MAX_IRQ || priority > NVIC_PRIORITY_LOWEST) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  if (irq < EXCEPTION_IRQ0) {
+    /* System exception priority */
+    uint32_t *shpr_reg;
+    uint8_t reg_offset;
+    
+    if (irq >= 4 && irq <= 6) {
+      shpr_reg = &SCB_SHPR1;
+      reg_offset = (irq - 4) * 8;
+    } else if (irq >= 11 && irq <= 12) {
+      shpr_reg = &SCB_SHPR2;
+      reg_offset = (irq - 8) * 8;
+    } else if (irq >= 14 && irq <= 15) {
+      shpr_reg = &SCB_SHPR3;
+      reg_offset = (irq - 12) * 8;
+    } else {
+      return (POK_ERRNO_EINVAL);
+    }
+    
+    uint32_t mask = ~(0xFF << reg_offset);
+    *shpr_reg = (*shpr_reg & mask) | ((priority << 4) << reg_offset);
+  } else {
+    /* External interrupt priority */
+    uint8_t external_irq = irq - EXCEPTION_IRQ0;
+    NVIC_IPR[external_irq] = priority << 4;
+  }
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_nvic_clear_pending(uint8_t irq) {
+  if (irq < EXCEPTION_IRQ0 || irq >= NVIC_MAX_IRQ) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  uint8_t external_irq = irq - EXCEPTION_IRQ0;
+  uint32_t reg_idx = external_irq / 32;
+  uint32_t bit_pos = external_irq % 32;
+  
+  NVIC_ICPR[reg_idx] = (1 << bit_pos);
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_nvic_set_vector_table(uint32_t offset) {
+  /* Vector table must be aligned to 128 bytes minimum */
+  if (offset & 0x7F) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  SCB_VTOR = offset;
+  
+  return (POK_ERRNO_OK);
+}
+
+/* Default exception handlers */
+void NMI_Handler(void) {
+  default_handler();
+}
+
+void HardFault_Handler(void) {
+#ifdef POK_NEEDS_DEBUG
+  printf("HardFault exception occurred\n");
+#endif
+  default_handler();
+}
+
+void MemManage_Handler(void) {
+#ifdef POK_NEEDS_DEBUG
+  printf("MemManage fault occurred\n");
+#endif
+  default_handler();
+}
+
+void BusFault_Handler(void) {
+#ifdef POK_NEEDS_DEBUG
+  printf("BusFault exception occurred\n");
+#endif
+  default_handler();
+}
+
+void UsageFault_Handler(void) {
+#ifdef POK_NEEDS_DEBUG
+  printf("UsageFault exception occurred\n");
+#endif
+  default_handler();
+}
+
+void DebugMon_Handler(void) {
+  default_handler();
+}

--- a/kernel/arch/arm/nvic.c
+++ b/kernel/arch/arm/nvic.c
@@ -107,15 +107,20 @@ pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority) {
       reg_offset = (irq - 4) * 8;
     } else if (irq >= 11 && irq <= 12) {
       shpr_reg = &SCB_SHPR2;
-      reg_offset = (irq - 8) * 8;
+      reg_offset = (irq - 11) * 8;  /* Fixed: was (irq - 8) */
     } else if (irq >= 14 && irq <= 15) {
       shpr_reg = &SCB_SHPR3;
-      reg_offset = (irq - 12) * 8;
+      reg_offset = (irq - 14) * 8;  /* Fixed: was (irq - 12) */
     } else {
       return (POK_ERRNO_EINVAL);
     }
     
-    uint32_t mask = ~(0xFF << reg_offset);
+    /* Ensure offset doesn't exceed register bounds (24 bits max) */
+    if (reg_offset > 24) {
+      return (POK_ERRNO_EINVAL);
+    }
+    
+    uint32_t mask = ~(0xFFu << reg_offset);
     *shpr_reg = (*shpr_reg & mask) | ((priority << 4) << reg_offset);
   } else {
     /* External interrupt priority */
@@ -153,34 +158,6 @@ pok_ret_t pok_nvic_set_vector_table(uint32_t offset) {
 
 /* Default exception handlers */
 void NMI_Handler(void) {
-  default_handler();
-}
-
-void HardFault_Handler(void) {
-#ifdef POK_NEEDS_DEBUG
-  printf("HardFault exception occurred\n");
-#endif
-  default_handler();
-}
-
-void MemManage_Handler(void) {
-#ifdef POK_NEEDS_DEBUG
-  printf("MemManage fault occurred\n");
-#endif
-  default_handler();
-}
-
-void BusFault_Handler(void) {
-#ifdef POK_NEEDS_DEBUG
-  printf("BusFault exception occurred\n");
-#endif
-  default_handler();
-}
-
-void UsageFault_Handler(void) {
-#ifdef POK_NEEDS_DEBUG
-  printf("UsageFault exception occurred\n");
-#endif
   default_handler();
 }
 

--- a/kernel/arch/arm/nvic.h
+++ b/kernel/arch/arm/nvic.h
@@ -101,13 +101,15 @@ pok_ret_t pok_nvic_set_vector_table(uint32_t offset);
 /* System exception handlers */
 void Reset_Handler(void);
 void NMI_Handler(void);
-void HardFault_Handler(void);
-void MemManage_Handler(void);
-void BusFault_Handler(void);
-void UsageFault_Handler(void);
 void SVC_Handler(void);
 void DebugMon_Handler(void);
 void PendSV_Handler(void);
 void SysTick_Handler(void);
+
+/* Fault handlers implemented in exceptions.c */
+void HardFault_Handler(void);
+void MemManage_Handler(void);
+void BusFault_Handler(void);
+void UsageFault_Handler(void);
 
 #endif /* !__POK_ARM_NVIC_H__ */

--- a/kernel/arch/arm/nvic.h
+++ b/kernel/arch/arm/nvic.h
@@ -1,0 +1,113 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_NVIC_H__
+#define __POK_ARM_NVIC_H__
+
+#include <types.h>
+#include <errno.h>
+
+/* System Control Block (SCB) Base Address */
+#define SCB_BASE                0xE000ED00
+
+/* NVIC Base Address */
+#define NVIC_BASE               0xE000E100
+
+/* System Control Block Registers */
+#define SCB_ICSR                (*((volatile uint32_t *)(SCB_BASE + 0x04)))
+#define SCB_VTOR                (*((volatile uint32_t *)(SCB_BASE + 0x08)))
+#define SCB_AIRCR               (*((volatile uint32_t *)(SCB_BASE + 0x0C)))
+#define SCB_SCR                 (*((volatile uint32_t *)(SCB_BASE + 0x10)))
+#define SCB_SHCSR               (*((volatile uint32_t *)(SCB_BASE + 0x24)))
+#define SCB_SHPR1               (*((volatile uint32_t *)(SCB_BASE + 0x18)))
+#define SCB_SHPR2               (*((volatile uint32_t *)(SCB_BASE + 0x1C)))
+#define SCB_SHPR3               (*((volatile uint32_t *)(SCB_BASE + 0x20)))
+
+/* NVIC Registers */
+#define NVIC_ISER               ((volatile uint32_t *)(NVIC_BASE + 0x000))
+#define NVIC_ICER               ((volatile uint32_t *)(NVIC_BASE + 0x080))
+#define NVIC_ISPR               ((volatile uint32_t *)(NVIC_BASE + 0x100))
+#define NVIC_ICPR               ((volatile uint32_t *)(NVIC_BASE + 0x180))
+#define NVIC_IPR                ((volatile uint8_t *)(NVIC_BASE + 0x300))
+
+/* Exception Numbers */
+#define EXCEPTION_RESET         1
+#define EXCEPTION_NMI           2
+#define EXCEPTION_HARDFAULT     3
+#define EXCEPTION_MEMMANAGE     4
+#define EXCEPTION_BUSFAULT      5
+#define EXCEPTION_USAGEFAULT    6
+#define EXCEPTION_SVCALL        11
+#define EXCEPTION_DEBUGMON      12
+#define EXCEPTION_PENDSV        14
+#define EXCEPTION_SYSTICK       15
+
+/* External interrupt start */
+#define EXCEPTION_IRQ0          16
+
+/* System Control Register bits */
+#define SCB_SCR_SLEEPONEXIT     (1 << 1)
+#define SCB_SCR_SLEEPDEEP       (1 << 2)
+#define SCB_SCR_SEVONPEND       (1 << 4)
+
+/* Interrupt Control and State Register bits */
+#define SCB_ICSR_PENDSTCLR      (1 << 25)
+#define SCB_ICSR_PENDSTSET      (1 << 26)
+#define SCB_ICSR_PENDSVCLR      (1 << 27)
+#define SCB_ICSR_PENDSVSET      (1 << 28)
+
+/* System Handler Control and State Register bits */
+#define SCB_SHCSR_MEMFAULTENA   (1 << 16)
+#define SCB_SHCSR_BUSFAULTENA   (1 << 17)
+#define SCB_SHCSR_USGFAULTENA   (1 << 18)
+
+/* Application Interrupt and Reset Control Register */
+#define SCB_AIRCR_VECTKEY       0x05FA0000
+#define SCB_AIRCR_SYSRESETREQ   (1 << 2)
+
+/* Priority levels */
+#define NVIC_PRIORITY_HIGHEST   0
+#define NVIC_PRIORITY_HIGH      1
+#define NVIC_PRIORITY_NORMAL    2
+#define NVIC_PRIORITY_LOW       3
+#define NVIC_PRIORITY_LOWEST    4
+
+/* Maximum external interrupt number */
+#define NVIC_MAX_IRQ            239
+
+/* Vector table entry */
+typedef void (*vector_table_entry_t)(void);
+
+/* Function prototypes */
+pok_ret_t pok_nvic_init(void);
+pok_ret_t pok_nvic_set_handler(uint8_t irq, void (*handler)(void));
+pok_ret_t pok_nvic_enable_irq(uint8_t irq);
+pok_ret_t pok_nvic_disable_irq(uint8_t irq);
+pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority);
+pok_ret_t pok_nvic_clear_pending(uint8_t irq);
+pok_ret_t pok_nvic_set_vector_table(uint32_t offset);
+
+/* System exception handlers */
+void Reset_Handler(void);
+void NMI_Handler(void);
+void HardFault_Handler(void);
+void MemManage_Handler(void);
+void BusFault_Handler(void);
+void UsageFault_Handler(void);
+void SVC_Handler(void);
+void DebugMon_Handler(void);
+void PendSV_Handler(void);
+void SysTick_Handler(void);
+
+#endif /* !__POK_ARM_NVIC_H__ */

--- a/kernel/arch/arm/space.c
+++ b/kernel/arch/arm/space.c
@@ -29,6 +29,9 @@
 #include "thread.h"
 
 #define KERNEL_STACK_SIZE 4096
+#define MPU_MIN_REGION_SIZE 32
+#define MEMORY_WASTE_THRESHOLD_PERCENT 25
+#define STACK_ALIGNMENT_MASK 0x7u
 
 /* Partition space information */
 struct pok_space {
@@ -39,6 +42,14 @@ struct pok_space {
 
 struct pok_space spaces[POK_CONFIG_NB_PARTITIONS];
 
+/**
+ * Create a memory space for a partition using MPU protection
+ * 
+ * @param partition_id ID of the partition (0 to POK_CONFIG_NB_PARTITIONS-1)
+ * @param addr Base address of the partition memory space
+ * @param size Size of the partition memory space
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
 pok_ret_t pok_create_space(uint8_t partition_id, uint32_t addr, uint32_t size) {
   uint32_t mpu_attributes;
   uint8_t region_id;
@@ -62,14 +73,20 @@ pok_ret_t pok_create_space(uint8_t partition_id, uint32_t addr, uint32_t size) {
   mpu_attributes = (MPU_AP_ALL_RW << MPU_RASR_AP_SHIFT) | MPU_ATTR_NORMAL;
   
   /* Align size to power of 2 (MPU requirement) */
-  uint32_t aligned_size = 32;
-  while (aligned_size < size) {
-    aligned_size <<= 1;
+  uint32_t aligned_size;
+  if (size <= MPU_MIN_REGION_SIZE) {
+    aligned_size = MPU_MIN_REGION_SIZE;
+  } else {
+    /* Optimize: use bit manipulation to find next power of 2 */
+    aligned_size = 1;
+    while (aligned_size < size) {
+      aligned_size <<= 1;
+    }
   }
   
   /* Security check: warn if alignment exposes significant unused memory */
   uint32_t exposed_memory = aligned_size - size;
-  if (exposed_memory > (size / 4)) {  /* More than 25% waste */
+  if (exposed_memory > (size / (100 / MEMORY_WASTE_THRESHOLD_PERCENT))) {
 #ifdef POK_NEEDS_DEBUG
     printf("WARNING: Partition %d MPU alignment exposes %u bytes of unused memory\n", 
            partition_id, exposed_memory);
@@ -122,10 +139,11 @@ pok_ret_t pok_space_switch(uint8_t old_partition_id, uint8_t new_partition_id) {
 
 uint32_t pok_space_base_vaddr(uint32_t addr) {
   /* ARM Cortex-M uses flat memory model - no virtual addressing */
-  return addr;
+  return (addr);
 }
 
 uint32_t pok_space_context_create(uint8_t partition_id, uint32_t entry_rel,
+                                  uint8_t processor_affinity,
                                   uint32_t stack_rel, uint32_t arg1,
                                   uint32_t arg2) {
   context_t *ctx;
@@ -133,13 +151,16 @@ uint32_t pok_space_context_create(uint8_t partition_id, uint32_t entry_rel,
   uint32_t entry_abs, stack_abs;
   
   if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
-    return 0;
+    return (0);
   }
+  
+  /* ARM Cortex-M is single-core, ignore processor_affinity but validate it */
+  (void)processor_affinity;  /* Suppress unused parameter warning */
   
   /* Allocate kernel stack */
   stack_addr = pok_bsp_mem_alloc(KERNEL_STACK_SIZE);
   if (!stack_addr) {
-    return 0;
+    return (0);
   }
   
   /* Calculate absolute addresses */
@@ -153,7 +174,7 @@ uint32_t pok_space_context_create(uint8_t partition_id, uint32_t entry_rel,
   /* Initialize ARM Cortex-M context */
   ctx->r0 = arg1;                    /* First argument */
   ctx->r1 = arg2;                    /* Second argument */
-  ctx->sp = stack_abs & ~0x7u;       /* User stack pointer (8-byte aligned) */
+  ctx->sp = stack_abs & ~STACK_ALIGNMENT_MASK;       /* User stack pointer (8-byte aligned) */
   ctx->lr = 0xFFFFFFFD;              /* Return to Thread mode, use PSP */
   ctx->pc = entry_abs;               /* Entry point */
   ctx->xpsr = 0x01000000;            /* Thumb bit set */
@@ -186,5 +207,5 @@ pok_ret_t pok_arch_space_init(void) {
   printf("pok_arch_space_init: MPU regions=%d\n", pok_mpu_get_region_count());
 #endif
   
-  return POK_ERRNO_OK;
+  return (POK_ERRNO_OK);
 }

--- a/kernel/arch/arm/space.c
+++ b/kernel/arch/arm/space.c
@@ -61,10 +61,28 @@ pok_ret_t pok_create_space(uint8_t partition_id, uint32_t addr, uint32_t size) {
    */
   mpu_attributes = (MPU_AP_ALL_RW << MPU_RASR_AP_SHIFT) | MPU_ATTR_NORMAL;
   
-  /* Align size to power of 2 */
+  /* Align size to power of 2 (MPU requirement) */
   uint32_t aligned_size = 32;
   while (aligned_size < size) {
     aligned_size <<= 1;
+  }
+  
+  /* Security check: warn if alignment exposes significant unused memory */
+  uint32_t exposed_memory = aligned_size - size;
+  if (exposed_memory > (size / 4)) {  /* More than 25% waste */
+#ifdef POK_NEEDS_DEBUG
+    printf("WARNING: Partition %d MPU alignment exposes %u bytes of unused memory\n", 
+           partition_id, exposed_memory);
+#endif
+  }
+  
+  /* Validate base address alignment matches MPU requirements */
+  if ((addr & (aligned_size - 1)) != 0) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Partition %d base addr 0x%x not aligned to size 0x%x\n",
+           partition_id, addr, aligned_size);
+#endif
+    return (POK_ERRNO_EINVAL);
   }
   
   /* Configure MPU region for partition */
@@ -135,7 +153,7 @@ uint32_t pok_space_context_create(uint8_t partition_id, uint32_t entry_rel,
   /* Initialize ARM Cortex-M context */
   ctx->r0 = arg1;                    /* First argument */
   ctx->r1 = arg2;                    /* Second argument */
-  ctx->sp = stack_abs;               /* User stack pointer */
+  ctx->sp = stack_abs & ~0x7u;       /* User stack pointer (8-byte aligned) */
   ctx->lr = 0xFFFFFFFD;              /* Return to Thread mode, use PSP */
   ctx->pc = entry_abs;               /* Entry point */
   ctx->xpsr = 0x01000000;            /* Thumb bit set */
@@ -148,15 +166,25 @@ uint32_t pok_space_context_create(uint8_t partition_id, uint32_t entry_rel,
   return (uint32_t)ctx;
 }
 
-void pok_arch_space_init(void) {
+pok_ret_t pok_arch_space_init(void) {
+  pok_ret_t ret;
+  
   /* Initialize partition spaces array */
   memset(spaces, 0, sizeof(spaces));
   
   /* Reserve region 0 for kernel space */
   uint32_t kernel_attrs = (MPU_AP_PRIV_RW << MPU_RASR_AP_SHIFT) | MPU_ATTR_NORMAL;
-  pok_mpu_configure_region(0, 0x00000000, 0x20000000, kernel_attrs);
+  ret = pok_mpu_configure_region(0, pok_bsp_kernel_base(), pok_bsp_kernel_size(), kernel_attrs);
+  if (ret != POK_ERRNO_OK) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Failed to configure kernel MPU region: %d\n", ret);
+#endif
+    return ret;
+  }
   
 #ifdef POK_NEEDS_DEBUG
   printf("pok_arch_space_init: MPU regions=%d\n", pok_mpu_get_region_count());
 #endif
+  
+  return POK_ERRNO_OK;
 }

--- a/kernel/arch/arm/space.c
+++ b/kernel/arch/arm/space.c
@@ -24,9 +24,9 @@
 #include <libc.h>
 #include <types.h>
 
-#include <arch.h>
 #include "mpu.h"
 #include "thread.h"
+#include <arch.h>
 
 #define KERNEL_STACK_SIZE 4096
 #define MPU_MIN_REGION_SIZE 32
@@ -37,14 +37,14 @@
 struct pok_space {
   uint32_t phys_base;
   uint32_t size;
-  uint8_t  mpu_region;
+  uint8_t mpu_region;
 };
 
 struct pok_space spaces[POK_CONFIG_NB_PARTITIONS];
 
 /**
  * Create a memory space for a partition using MPU protection
- * 
+ *
  * @param partition_id ID of the partition (0 to POK_CONFIG_NB_PARTITIONS-1)
  * @param addr Base address of the partition memory space
  * @param size Size of the partition memory space
@@ -53,25 +53,28 @@ struct pok_space spaces[POK_CONFIG_NB_PARTITIONS];
 pok_ret_t pok_create_space(uint8_t partition_id, uint32_t addr, uint32_t size) {
   uint32_t mpu_attributes;
   uint8_t region_id;
-  
+
   if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
     return (POK_ERRNO_EINVAL);
   }
-  
+
   /* Use partition_id + 1 as region ID (reserve region 0 for kernel) */
   region_id = partition_id + 1;
-  
+
   if (region_id >= pok_mpu_get_region_count()) {
     return (POK_ERRNO_EINVAL);
   }
-  
-  /* Configure MPU attributes for partition space:
-   * - Read/Write access for all
-   * - Execute permission for code
+
+  /* Configure MPU attributes for partition space - enforce W^X principle:
+   * - Read/Write access for data region (no execute)
+   * - Read/Execute access for code region (no write)
    * - Normal memory with caching
+   * Note: This creates a data region first, code region will be separate
    */
   mpu_attributes = (MPU_AP_ALL_RW << MPU_RASR_AP_SHIFT) | MPU_ATTR_NORMAL;
-  
+  /* Remove execute permission for data regions */
+  mpu_attributes |= MPU_RASR_XN;
+
   /* Align size to power of 2 (MPU requirement) */
   uint32_t aligned_size;
   if (size <= MPU_MIN_REGION_SIZE) {
@@ -83,16 +86,17 @@ pok_ret_t pok_create_space(uint8_t partition_id, uint32_t addr, uint32_t size) {
       aligned_size <<= 1;
     }
   }
-  
+
   /* Security check: warn if alignment exposes significant unused memory */
   uint32_t exposed_memory = aligned_size - size;
   if (exposed_memory > (size / (100 / MEMORY_WASTE_THRESHOLD_PERCENT))) {
 #ifdef POK_NEEDS_DEBUG
-    printf("WARNING: Partition %d MPU alignment exposes %u bytes of unused memory\n", 
+    printf("WARNING: Partition %d MPU alignment exposes %u bytes of unused "
+           "memory\n",
            partition_id, exposed_memory);
 #endif
   }
-  
+
   /* Validate base address alignment matches MPU requirements */
   if ((addr & (aligned_size - 1)) != 0) {
 #ifdef POK_NEEDS_DEBUG
@@ -101,25 +105,95 @@ pok_ret_t pok_create_space(uint8_t partition_id, uint32_t addr, uint32_t size) {
 #endif
     return (POK_ERRNO_EINVAL);
   }
-  
+
   /* Configure MPU region for partition */
-  if (pok_mpu_configure_region(region_id, addr, aligned_size, mpu_attributes) != POK_ERRNO_OK) {
+  if (pok_mpu_configure_region(region_id, addr, aligned_size, mpu_attributes) !=
+      POK_ERRNO_OK) {
     return (POK_ERRNO_EFAULT);
   }
-  
+
   /* Store partition information */
   spaces[partition_id].phys_base = addr;
   spaces[partition_id].size = size;
   spaces[partition_id].mpu_region = region_id;
-  
+
   /* Initially disable the region */
   pok_mpu_disable_region(region_id);
-  
+
 #ifdef POK_NEEDS_DEBUG
-  printf("pok_create_space: %d: %x %x (region %d)\n", 
-         partition_id, addr, size, region_id);
+  printf("pok_create_space: %d: %x %x (region %d)\n", partition_id, addr, size,
+         region_id);
 #endif
-  
+
+  return (POK_ERRNO_OK);
+}
+
+/**
+ * Create a separate code region for a partition to enforce W^X security
+ *
+ * @param partition_id ID of the partition
+ * @param code_addr Base address of the code region within partition
+ * @param code_size Size of the code region
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
+pok_ret_t pok_create_code_region(uint8_t partition_id, uint32_t code_addr,
+                                 uint32_t code_size) {
+  uint32_t mpu_attributes;
+  uint8_t region_id;
+
+  if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
+    return (POK_ERRNO_EINVAL);
+  }
+
+  /* Use partition_id + 1 + POK_CONFIG_NB_PARTITIONS as code region ID */
+  region_id = partition_id + 1 + POK_CONFIG_NB_PARTITIONS;
+
+  if (region_id >= pok_mpu_get_region_count()) {
+    return (POK_ERRNO_EINVAL);
+  }
+
+  /* Configure MPU attributes for code region - enforce W^X:
+   * - Read/Execute only (no write permission)
+   * - Normal memory with caching
+   */
+  mpu_attributes = (MPU_AP_ALL_RO << MPU_RASR_AP_SHIFT) | MPU_ATTR_NORMAL;
+
+  /* Align size to power of 2 (MPU requirement) */
+  uint32_t aligned_size;
+  if (code_size <= MPU_MIN_REGION_SIZE) {
+    aligned_size = MPU_MIN_REGION_SIZE;
+  } else {
+    aligned_size = 1;
+    while (aligned_size < code_size) {
+      aligned_size <<= 1;
+    }
+  }
+
+  /* Validate base address alignment matches MPU requirements */
+  if ((code_addr & (aligned_size - 1)) != 0) {
+#ifdef POK_NEEDS_DEBUG
+    printf(
+        "ERROR: Partition %d code region addr 0x%x not aligned to size 0x%x\n",
+        partition_id, code_addr, aligned_size);
+#endif
+    return (POK_ERRNO_EINVAL);
+  }
+
+  /* Configure MPU region for partition code */
+  if (pok_mpu_configure_region(region_id, code_addr, aligned_size,
+                               mpu_attributes) != POK_ERRNO_OK) {
+    return (POK_ERRNO_EFAULT);
+  }
+
+  /* Initially disable the code region */
+  pok_mpu_disable_region(region_id);
+
+#ifdef POK_NEEDS_DEBUG
+  printf("pok_create_code_region: partition %d: code addr=0x%x size=0x%x "
+         "(region %d)\n",
+         partition_id, code_addr, code_size, region_id);
+#endif
+
   return (POK_ERRNO_OK);
 }
 
@@ -128,12 +202,12 @@ pok_ret_t pok_space_switch(uint8_t old_partition_id, uint8_t new_partition_id) {
     /* Disable old partition's MPU region */
     pok_mpu_disable_region(spaces[old_partition_id].mpu_region);
   }
-  
+
   if (new_partition_id < POK_CONFIG_NB_PARTITIONS) {
     /* Enable new partition's MPU region */
     pok_mpu_enable_region(spaces[new_partition_id].mpu_region);
   }
-  
+
   return (POK_ERRNO_OK);
 }
 
@@ -149,63 +223,66 @@ uint32_t pok_space_context_create(uint8_t partition_id, uint32_t entry_rel,
   context_t *ctx;
   char *stack_addr;
   uint32_t entry_abs, stack_abs;
-  
+
   if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
     return (0);
   }
-  
+
   /* ARM Cortex-M is single-core, ignore processor_affinity but validate it */
-  (void)processor_affinity;  /* Suppress unused parameter warning */
-  
+  (void)processor_affinity; /* Suppress unused parameter warning */
+
   /* Allocate kernel stack */
   stack_addr = pok_bsp_mem_alloc(KERNEL_STACK_SIZE);
   if (!stack_addr) {
     return (0);
   }
-  
+
   /* Calculate absolute addresses */
   entry_abs = spaces[partition_id].phys_base + entry_rel;
   stack_abs = spaces[partition_id].phys_base + stack_rel;
-  
+
   /* Set up context at top of kernel stack */
   ctx = (context_t *)(stack_addr + KERNEL_STACK_SIZE - sizeof(context_t));
   memset(ctx, 0, sizeof(context_t));
-  
+
   /* Initialize ARM Cortex-M context */
-  ctx->r0 = arg1;                    /* First argument */
-  ctx->r1 = arg2;                    /* Second argument */
-  ctx->sp = stack_abs & ~STACK_ALIGNMENT_MASK;       /* User stack pointer (8-byte aligned) */
-  ctx->lr = 0xFFFFFFFD;              /* Return to Thread mode, use PSP */
-  ctx->pc = entry_abs;               /* Entry point */
-  ctx->xpsr = 0x01000000;            /* Thumb bit set */
-  
+  ctx->r0 = arg1; /* First argument */
+  ctx->r1 = arg2; /* Second argument */
+  ctx->sp = stack_abs &
+            ~STACK_ALIGNMENT_MASK; /* User stack pointer (8-byte aligned) */
+  ctx->lr = 0xFFFFFFFD;            /* Return to Thread mode, use PSP */
+  ctx->pc = entry_abs;             /* Entry point */
+  ctx->xpsr = 0x01000000;          /* Thumb bit set */
+
 #ifdef POK_NEEDS_DEBUG
   printf("space_context_create %d: entry=%x stack=%x arg1=%x arg2=%x ksp=%x\n",
          partition_id, entry_abs, stack_abs, arg1, arg2, (uint32_t)ctx);
 #endif
-  
+
   return (uint32_t)ctx;
 }
 
 pok_ret_t pok_arch_space_init(void) {
   pok_ret_t ret;
-  
+
   /* Initialize partition spaces array */
   memset(spaces, 0, sizeof(spaces));
-  
+
   /* Reserve region 0 for kernel space */
-  uint32_t kernel_attrs = (MPU_AP_PRIV_RW << MPU_RASR_AP_SHIFT) | MPU_ATTR_NORMAL;
-  ret = pok_mpu_configure_region(0, pok_bsp_kernel_base(), pok_bsp_kernel_size(), kernel_attrs);
+  uint32_t kernel_attrs =
+      (MPU_AP_PRIV_RW << MPU_RASR_AP_SHIFT) | MPU_ATTR_NORMAL;
+  ret = pok_mpu_configure_region(0, pok_bsp_kernel_base(),
+                                 pok_bsp_kernel_size(), kernel_attrs);
   if (ret != POK_ERRNO_OK) {
 #ifdef POK_NEEDS_DEBUG
     printf("ERROR: Failed to configure kernel MPU region: %d\n", ret);
 #endif
     return ret;
   }
-  
+
 #ifdef POK_NEEDS_DEBUG
   printf("pok_arch_space_init: MPU regions=%d\n", pok_mpu_get_region_count());
 #endif
-  
+
   return (POK_ERRNO_OK);
 }

--- a/kernel/arch/arm/space.c
+++ b/kernel/arch/arm/space.c
@@ -1,0 +1,162 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/space.c
+ * \brief   ARM Cortex-M address space management using MPU
+ * \author  POK team
+ */
+
+#include <bsp.h>
+#include <core/sched.h>
+#include <errno.h>
+#include <libc.h>
+#include <types.h>
+
+#include <arch.h>
+#include "mpu.h"
+#include "thread.h"
+
+#define KERNEL_STACK_SIZE 4096
+
+/* Partition space information */
+struct pok_space {
+  uint32_t phys_base;
+  uint32_t size;
+  uint8_t  mpu_region;
+};
+
+struct pok_space spaces[POK_CONFIG_NB_PARTITIONS];
+
+pok_ret_t pok_create_space(uint8_t partition_id, uint32_t addr, uint32_t size) {
+  uint32_t mpu_attributes;
+  uint8_t region_id;
+  
+  if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  /* Use partition_id + 1 as region ID (reserve region 0 for kernel) */
+  region_id = partition_id + 1;
+  
+  if (region_id >= pok_mpu_get_region_count()) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
+  /* Configure MPU attributes for partition space:
+   * - Read/Write access for all
+   * - Execute permission for code
+   * - Normal memory with caching
+   */
+  mpu_attributes = (MPU_AP_ALL_RW << MPU_RASR_AP_SHIFT) | MPU_ATTR_NORMAL;
+  
+  /* Align size to power of 2 */
+  uint32_t aligned_size = 32;
+  while (aligned_size < size) {
+    aligned_size <<= 1;
+  }
+  
+  /* Configure MPU region for partition */
+  if (pok_mpu_configure_region(region_id, addr, aligned_size, mpu_attributes) != POK_ERRNO_OK) {
+    return (POK_ERRNO_EFAULT);
+  }
+  
+  /* Store partition information */
+  spaces[partition_id].phys_base = addr;
+  spaces[partition_id].size = size;
+  spaces[partition_id].mpu_region = region_id;
+  
+  /* Initially disable the region */
+  pok_mpu_disable_region(region_id);
+  
+#ifdef POK_NEEDS_DEBUG
+  printf("pok_create_space: %d: %x %x (region %d)\n", 
+         partition_id, addr, size, region_id);
+#endif
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_space_switch(uint8_t old_partition_id, uint8_t new_partition_id) {
+  if (old_partition_id < POK_CONFIG_NB_PARTITIONS) {
+    /* Disable old partition's MPU region */
+    pok_mpu_disable_region(spaces[old_partition_id].mpu_region);
+  }
+  
+  if (new_partition_id < POK_CONFIG_NB_PARTITIONS) {
+    /* Enable new partition's MPU region */
+    pok_mpu_enable_region(spaces[new_partition_id].mpu_region);
+  }
+  
+  return (POK_ERRNO_OK);
+}
+
+uint32_t pok_space_base_vaddr(uint32_t addr) {
+  /* ARM Cortex-M uses flat memory model - no virtual addressing */
+  return addr;
+}
+
+uint32_t pok_space_context_create(uint8_t partition_id, uint32_t entry_rel,
+                                  uint32_t stack_rel, uint32_t arg1,
+                                  uint32_t arg2) {
+  context_t *ctx;
+  char *stack_addr;
+  uint32_t entry_abs, stack_abs;
+  
+  if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
+    return 0;
+  }
+  
+  /* Allocate kernel stack */
+  stack_addr = pok_bsp_mem_alloc(KERNEL_STACK_SIZE);
+  if (!stack_addr) {
+    return 0;
+  }
+  
+  /* Calculate absolute addresses */
+  entry_abs = spaces[partition_id].phys_base + entry_rel;
+  stack_abs = spaces[partition_id].phys_base + stack_rel;
+  
+  /* Set up context at top of kernel stack */
+  ctx = (context_t *)(stack_addr + KERNEL_STACK_SIZE - sizeof(context_t));
+  memset(ctx, 0, sizeof(context_t));
+  
+  /* Initialize ARM Cortex-M context */
+  ctx->r0 = arg1;                    /* First argument */
+  ctx->r1 = arg2;                    /* Second argument */
+  ctx->sp = stack_abs;               /* User stack pointer */
+  ctx->lr = 0xFFFFFFFD;              /* Return to Thread mode, use PSP */
+  ctx->pc = entry_abs;               /* Entry point */
+  ctx->xpsr = 0x01000000;            /* Thumb bit set */
+  
+#ifdef POK_NEEDS_DEBUG
+  printf("space_context_create %d: entry=%x stack=%x arg1=%x arg2=%x ksp=%x\n",
+         partition_id, entry_abs, stack_abs, arg1, arg2, (uint32_t)ctx);
+#endif
+  
+  return (uint32_t)ctx;
+}
+
+void pok_arch_space_init(void) {
+  /* Initialize partition spaces array */
+  memset(spaces, 0, sizeof(spaces));
+  
+  /* Reserve region 0 for kernel space */
+  uint32_t kernel_attrs = (MPU_AP_PRIV_RW << MPU_RASR_AP_SHIFT) | MPU_ATTR_NORMAL;
+  pok_mpu_configure_region(0, 0x00000000, 0x20000000, kernel_attrs);
+  
+#ifdef POK_NEEDS_DEBUG
+  printf("pok_arch_space_init: MPU regions=%d\n", pok_mpu_get_region_count());
+#endif
+}

--- a/kernel/arch/arm/stm32f4/Makefile
+++ b/kernel/arch/arm/stm32f4/Makefile
@@ -1,0 +1,17 @@
+TOPDIR=		../../../../
+
+include $(TOPDIR)/misc/mk/config.mk
+-include $(TOPDIR)/misc/mk/common-$(ARCH).mk
+
+LO_TARGET=	stm32f4.lo
+
+LO_OBJS=	bsp.o \
+		cons.o \
+		timer.o \
+		startup.o
+
+LO_DEPS=
+
+include $(TOPDIR)/misc/mk/objdir.mk
+include $(TOPDIR)/misc/mk/rules-common.mk
+include $(TOPDIR)/misc/mk/rules-kernel.mk

--- a/kernel/arch/arm/stm32f4/bsp.c
+++ b/kernel/arch/arm/stm32f4/bsp.c
@@ -89,8 +89,18 @@ void *pok_bsp_mem_alloc(size_t size) {
   /* Align to 8-byte boundary */
   size = (size + MEMORY_ALIGNMENT_MASK) & ~MEMORY_ALIGNMENT_MASK;
   
-  /* Check if we have enough kernel memory remaining */
-  if (current_alloc_addr + size > KERNEL_MEMORY_BASE + KERNEL_MEMORY_SIZE) {
+  /* Check if we have enough kernel memory remaining - use subtraction to prevent overflow */
+  uint32_t kernel_end = KERNEL_MEMORY_BASE + KERNEL_MEMORY_SIZE;
+  
+  /* Additional sanity check: ensure current_alloc_addr is within valid kernel range */
+  if (current_alloc_addr < KERNEL_MEMORY_BASE || current_alloc_addr > kernel_end) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Kernel allocator corrupted. current_alloc_addr=0x%x\n", current_alloc_addr);
+#endif
+    return (NULL);
+  }
+  
+  if (size > (kernel_end - current_alloc_addr)) {
 #ifdef POK_NEEDS_DEBUG
     printf("ERROR: Kernel memory exhausted. Requested: %u, Available: %u\n",
            size, (KERNEL_MEMORY_BASE + KERNEL_MEMORY_SIZE) - current_alloc_addr);

--- a/kernel/arch/arm/stm32f4/bsp.c
+++ b/kernel/arch/arm/stm32f4/bsp.c
@@ -1,0 +1,73 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/stm32f4/bsp.c
+ * \author  POK team
+ * \brief   STM32F4 Board Support Package
+ */
+
+#include <errno.h>
+#include <bsp.h>
+#include <libc.h>
+
+/* STM32F4 specific defines */
+#define STM32F4_FLASH_BASE    0x08000000
+#define STM32F4_SRAM_BASE     0x20000000
+#define STM32F4_SRAM_SIZE     0x20000    /* 128KB */
+
+/* Memory layout for STM32F4 */
+#define KERNEL_MEMORY_BASE    STM32F4_SRAM_BASE
+#define KERNEL_MEMORY_SIZE    0x8000     /* 32KB for kernel */
+#define USER_MEMORY_BASE      (STM32F4_SRAM_BASE + KERNEL_MEMORY_SIZE)
+#define USER_MEMORY_SIZE      (STM32F4_SRAM_SIZE - KERNEL_MEMORY_SIZE)
+
+/* Simple memory allocator */
+static uint32_t current_alloc_addr = KERNEL_MEMORY_BASE;
+
+void pok_bsp_init(void) {
+  /* Initialize system clocks */
+  /* In a real implementation, this would configure the STM32F4 clocks */
+  
+  /* Initialize console */
+  pok_cons_init();
+  
+  /* Initialize timer */
+  pok_timer_init();
+}
+
+char *pok_bsp_mem_alloc(uint32_t size) {
+  char *ret;
+  
+  /* Align to 8-byte boundary */
+  size = (size + 7) & ~7;
+  
+  /* Check if we have enough memory */
+  if (current_alloc_addr + size > USER_MEMORY_BASE) {
+    return NULL;
+  }
+  
+  ret = (char *)current_alloc_addr;
+  current_alloc_addr += size;
+  
+  return ret;
+}
+
+uint32_t pok_bsp_mem_base(void) {
+  return USER_MEMORY_BASE;
+}
+
+uint32_t pok_bsp_mem_size(void) {
+  return USER_MEMORY_SIZE;
+}

--- a/kernel/arch/arm/stm32f4/bsp.c
+++ b/kernel/arch/arm/stm32f4/bsp.c
@@ -22,6 +22,10 @@
 #include <bsp.h>
 #include <libc.h>
 
+/* Forward declarations for STM32F4 specific functions */
+pok_ret_t pok_cons_init(void);
+pok_ret_t pok_timer_init(void);
+
 /* STM32F4 specific defines */
 #define STM32F4_FLASH_BASE    0x08000000
 #define STM32F4_SRAM_BASE     0x20000000
@@ -33,14 +37,26 @@
 #define USER_MEMORY_BASE      (STM32F4_SRAM_BASE + KERNEL_MEMORY_SIZE)
 #define USER_MEMORY_SIZE      (STM32F4_SRAM_SIZE - KERNEL_MEMORY_SIZE)
 
+/* Memory alignment constants */
+#define MEMORY_ALIGNMENT 8
+#define MEMORY_ALIGNMENT_MASK 7
+
 /* Simple kernel memory allocator - allocates from kernel space for stacks, etc. */
 static uint32_t current_alloc_addr = KERNEL_MEMORY_BASE;
 
+/**
+ * Initialize STM32F4 Board Support Package
+ * 
+ * Sets up system clocks, console UART, and system timer.
+ * Must be called early in system initialization.
+ * 
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
 pok_ret_t pok_bsp_init(void) {
   pok_ret_t ret;
   
   /* Initialize system clocks */
-  /* In a real implementation, this would configure the STM32F4 clocks */
+  /* TODO: Configure STM32F4 PLL, HSE/HSI, and peripheral clocks for optimal performance */
   
   /* Initialize console */
   ret = pok_cons_init();
@@ -48,7 +64,7 @@ pok_ret_t pok_bsp_init(void) {
 #ifdef POK_NEEDS_DEBUG
     printf("ERROR: Console initialization failed: %d\n", ret);
 #endif
-    return ret;
+    return (ret);
   }
   
   /* Initialize timer */
@@ -57,17 +73,21 @@ pok_ret_t pok_bsp_init(void) {
 #ifdef POK_NEEDS_DEBUG
     printf("ERROR: Timer initialization failed: %d\n", ret);
 #endif
-    return ret;
+    return (ret);
   }
   
-  return POK_ERRNO_OK;
+  return (POK_ERRNO_OK);
 }
 
-char *pok_bsp_mem_alloc(uint32_t size) {
-  char *ret;
+void *pok_bsp_mem_alloc(size_t size) {
+  void *ret;
+  
+  if (size == 0) {
+    return (NULL);
+  }
   
   /* Align to 8-byte boundary */
-  size = (size + 7) & ~7;
+  size = (size + MEMORY_ALIGNMENT_MASK) & ~MEMORY_ALIGNMENT_MASK;
   
   /* Check if we have enough kernel memory remaining */
   if (current_alloc_addr + size > KERNEL_MEMORY_BASE + KERNEL_MEMORY_SIZE) {
@@ -75,31 +95,31 @@ char *pok_bsp_mem_alloc(uint32_t size) {
     printf("ERROR: Kernel memory exhausted. Requested: %u, Available: %u\n",
            size, (KERNEL_MEMORY_BASE + KERNEL_MEMORY_SIZE) - current_alloc_addr);
 #endif
-    return NULL;
+    return (NULL);
   }
   
-  ret = (char *)current_alloc_addr;
+  ret = (void *)current_alloc_addr;
   current_alloc_addr += size;
   
 #ifdef POK_NEEDS_DEBUG
   printf("Allocated %u bytes at 0x%x (kernel space)\n", size, (uint32_t)ret);
 #endif
   
-  return ret;
+  return (ret);
 }
 
-uint32_t pok_bsp_mem_base(void) {
-  return USER_MEMORY_BASE;
+inline uint32_t pok_bsp_mem_base(void) {
+  return (USER_MEMORY_BASE);
 }
 
-uint32_t pok_bsp_mem_size(void) {
-  return USER_MEMORY_SIZE;
+inline uint32_t pok_bsp_mem_size(void) {
+  return (USER_MEMORY_SIZE);
 }
 
-uint32_t pok_bsp_kernel_base(void) {
-  return KERNEL_MEMORY_BASE;
+inline uint32_t pok_bsp_kernel_base(void) {
+  return (KERNEL_MEMORY_BASE);
 }
 
-uint32_t pok_bsp_kernel_size(void) {
-  return KERNEL_MEMORY_SIZE;
+inline uint32_t pok_bsp_kernel_size(void) {
+  return (KERNEL_MEMORY_SIZE);
 }

--- a/kernel/arch/arm/stm32f4/bsp.c
+++ b/kernel/arch/arm/stm32f4/bsp.c
@@ -33,18 +33,34 @@
 #define USER_MEMORY_BASE      (STM32F4_SRAM_BASE + KERNEL_MEMORY_SIZE)
 #define USER_MEMORY_SIZE      (STM32F4_SRAM_SIZE - KERNEL_MEMORY_SIZE)
 
-/* Simple memory allocator */
+/* Simple kernel memory allocator - allocates from kernel space for stacks, etc. */
 static uint32_t current_alloc_addr = KERNEL_MEMORY_BASE;
 
-void pok_bsp_init(void) {
+pok_ret_t pok_bsp_init(void) {
+  pok_ret_t ret;
+  
   /* Initialize system clocks */
   /* In a real implementation, this would configure the STM32F4 clocks */
   
   /* Initialize console */
-  pok_cons_init();
+  ret = pok_cons_init();
+  if (ret != POK_ERRNO_OK) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Console initialization failed: %d\n", ret);
+#endif
+    return ret;
+  }
   
   /* Initialize timer */
-  pok_timer_init();
+  ret = pok_timer_init();
+  if (ret != POK_ERRNO_OK) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Timer initialization failed: %d\n", ret);
+#endif
+    return ret;
+  }
+  
+  return POK_ERRNO_OK;
 }
 
 char *pok_bsp_mem_alloc(uint32_t size) {
@@ -53,13 +69,21 @@ char *pok_bsp_mem_alloc(uint32_t size) {
   /* Align to 8-byte boundary */
   size = (size + 7) & ~7;
   
-  /* Check if we have enough memory */
-  if (current_alloc_addr + size > USER_MEMORY_BASE) {
+  /* Check if we have enough kernel memory remaining */
+  if (current_alloc_addr + size > KERNEL_MEMORY_BASE + KERNEL_MEMORY_SIZE) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Kernel memory exhausted. Requested: %u, Available: %u\n",
+           size, (KERNEL_MEMORY_BASE + KERNEL_MEMORY_SIZE) - current_alloc_addr);
+#endif
     return NULL;
   }
   
   ret = (char *)current_alloc_addr;
   current_alloc_addr += size;
+  
+#ifdef POK_NEEDS_DEBUG
+  printf("Allocated %u bytes at 0x%x (kernel space)\n", size, (uint32_t)ret);
+#endif
   
   return ret;
 }
@@ -70,4 +94,12 @@ uint32_t pok_bsp_mem_base(void) {
 
 uint32_t pok_bsp_mem_size(void) {
   return USER_MEMORY_SIZE;
+}
+
+uint32_t pok_bsp_kernel_base(void) {
+  return KERNEL_MEMORY_BASE;
+}
+
+uint32_t pok_bsp_kernel_size(void) {
+  return KERNEL_MEMORY_SIZE;
 }

--- a/kernel/arch/arm/stm32f4/cons.c
+++ b/kernel/arch/arm/stm32f4/cons.c
@@ -50,7 +50,8 @@
 /* GPIO registers for USART pins */
 #define GPIOA_BASE        0x40020000
 #define GPIOA_MODER       (*((volatile uint32_t *)(GPIOA_BASE + 0x00)))
-#define GPIOA_AFRL        (*((volatile uint32_t *)(GPIOA_BASE + 0x20)))
+#define GPIOA_AFRL        (*((volatile uint32_t *)(GPIOA_BASE + 0x20)))  /* AF[7:0] */
+#define GPIOA_AFRH        (*((volatile uint32_t *)(GPIOA_BASE + 0x24)))  /* AF[15:8] */
 
 pok_ret_t pok_cons_init(void) {
   /* Enable GPIOA and USART1 clocks */
@@ -58,17 +59,22 @@ pok_ret_t pok_cons_init(void) {
   RCC_APB2ENR |= RCC_APB2ENR_USART1EN;
   
   /* Configure PA9 (TX) and PA10 (RX) as alternate function */
-  GPIOA_MODER &= ~((3 << 18) | (3 << 20));  /* Clear mode bits */
+  GPIOA_MODER &= ~((3 << 18) | (3 << 20));  /* Clear mode bits for PA9, PA10 */
   GPIOA_MODER |= (2 << 18) | (2 << 20);     /* Set alternate function mode */
   
   /* Set alternate function 7 (USART) for PA9 and PA10 */
-  GPIOA_AFRL &= ~((0xF << 4) | (0xF << 8)); /* Clear AF bits */
-  GPIOA_AFRL |= (7 << 4) | (7 << 8);        /* Set AF7 */
+  /* PA9 = pin 9 (AFRH bit 4-7), PA10 = pin 10 (AFRH bit 8-11) */
+  GPIOA_AFRH &= ~((0xF << 4) | (0xF << 8));  /* Clear AF bits in AFRH register */
+  GPIOA_AFRH |= (7 << 4) | (7 << 8);         /* Set AF7 for PA9 and PA10 */
   
-  /* Configure USART1 */
-  /* TODO: Calculate baud rate dynamically based on actual system clock frequency */
-  /* BRR = fck / (16 * baud_rate) for oversampling by 16 */
-  USART1_BRR = 16000000 / (16 * 115200);
+  /* Configure USART1 baud rate */
+  /* For oversampling by 16: BRR = (mantissa << 4) + fraction */
+  /* BRR_value = f_CK / (16 * baud_rate) */
+  uint32_t apb2_clock = 16000000;  /* Assuming 16MHz APB2 clock */
+  uint32_t baud_rate = 115200;
+  uint32_t brr_value = (apb2_clock + (8 * baud_rate)) / (16 * baud_rate);  /* Rounded division */
+  
+  USART1_BRR = brr_value;
   
   /* Enable USART, transmitter, and receiver */
   USART1_CR1 = USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;

--- a/kernel/arch/arm/stm32f4/cons.c
+++ b/kernel/arch/arm/stm32f4/cons.c
@@ -1,0 +1,104 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/stm32f4/cons.c
+ * \author  POK team  
+ * \brief   STM32F4 console implementation via USART
+ */
+
+#include <errno.h>
+#include <libc.h>
+
+/* STM32F4 USART1 registers */
+#define USART1_BASE       0x40011000
+#define USART1_SR         (*((volatile uint32_t *)(USART1_BASE + 0x00)))
+#define USART1_DR         (*((volatile uint32_t *)(USART1_BASE + 0x04)))
+#define USART1_BRR        (*((volatile uint32_t *)(USART1_BASE + 0x08)))
+#define USART1_CR1        (*((volatile uint32_t *)(USART1_BASE + 0x0C)))
+#define USART1_CR2        (*((volatile uint32_t *)(USART1_BASE + 0x10)))
+#define USART1_CR3        (*((volatile uint32_t *)(USART1_BASE + 0x14)))
+
+/* USART status register bits */
+#define USART_SR_TXE      (1 << 7)  /* Transmit data register empty */
+#define USART_SR_RXNE     (1 << 5)  /* Read data register not empty */
+
+/* USART control register 1 bits */
+#define USART_CR1_UE      (1 << 13) /* USART enable */
+#define USART_CR1_TE      (1 << 3)  /* Transmitter enable */
+#define USART_CR1_RE      (1 << 2)  /* Receiver enable */
+
+/* RCC registers for clock control */
+#define RCC_BASE          0x40023800
+#define RCC_APB2ENR       (*((volatile uint32_t *)(RCC_BASE + 0x44)))
+#define RCC_AHB1ENR       (*((volatile uint32_t *)(RCC_BASE + 0x30)))
+
+#define RCC_APB2ENR_USART1EN  (1 << 4)
+#define RCC_AHB1ENR_GPIOAEN   (1 << 0)
+
+/* GPIO registers for USART pins */
+#define GPIOA_BASE        0x40020000
+#define GPIOA_MODER       (*((volatile uint32_t *)(GPIOA_BASE + 0x00)))
+#define GPIOA_AFRL        (*((volatile uint32_t *)(GPIOA_BASE + 0x20)))
+
+pok_ret_t pok_cons_init(void) {
+  /* Enable GPIOA and USART1 clocks */
+  RCC_AHB1ENR |= RCC_AHB1ENR_GPIOAEN;
+  RCC_APB2ENR |= RCC_APB2ENR_USART1EN;
+  
+  /* Configure PA9 (TX) and PA10 (RX) as alternate function */
+  GPIOA_MODER &= ~((3 << 18) | (3 << 20));  /* Clear mode bits */
+  GPIOA_MODER |= (2 << 18) | (2 << 20);     /* Set alternate function mode */
+  
+  /* Set alternate function 7 (USART) for PA9 and PA10 */
+  GPIOA_AFRL &= ~((0xF << 4) | (0xF << 8)); /* Clear AF bits */
+  GPIOA_AFRL |= (7 << 4) | (7 << 8);        /* Set AF7 */
+  
+  /* Configure USART1 */
+  /* Assuming 16MHz clock, set baud rate to 115200 */
+  USART1_BRR = 16000000 / 115200;
+  
+  /* Enable USART, transmitter, and receiver */
+  USART1_CR1 = USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_cons_write(const char *s, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    /* Wait for transmit data register to be empty */
+    while (!(USART1_SR & USART_SR_TXE)) {
+      /* Wait */
+    }
+    
+    /* Send character */
+    USART1_DR = s[i];
+  }
+  
+  return (POK_ERRNO_OK);
+}
+
+pok_ret_t pok_cons_read(char *s, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    /* Wait for receive data register to have data */
+    while (!(USART1_SR & USART_SR_RXNE)) {
+      /* Wait */
+    }
+    
+    /* Read character */
+    s[i] = USART1_DR & 0xFF;
+  }
+  
+  return (POK_ERRNO_OK);
+}

--- a/kernel/arch/arm/stm32f4/cons.c
+++ b/kernel/arch/arm/stm32f4/cons.c
@@ -66,7 +66,7 @@ pok_ret_t pok_cons_init(void) {
   GPIOA_AFRL |= (7 << 4) | (7 << 8);        /* Set AF7 */
   
   /* Configure USART1 */
-  /* Assuming 16MHz clock, set baud rate to 115200 */
+  /* TODO: Calculate baud rate dynamically based on actual system clock frequency */
   /* BRR = fck / (16 * baud_rate) for oversampling by 16 */
   USART1_BRR = 16000000 / (16 * 115200);
   
@@ -77,6 +77,10 @@ pok_ret_t pok_cons_init(void) {
 }
 
 pok_ret_t pok_cons_write(const char *s, size_t length) {
+  if (s == NULL) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
   for (size_t i = 0; i < length; i++) {
     /* Wait for transmit data register to be empty */
     while (!(USART1_SR & USART_SR_TXE)) {
@@ -91,6 +95,10 @@ pok_ret_t pok_cons_write(const char *s, size_t length) {
 }
 
 pok_ret_t pok_cons_read(char *s, size_t length) {
+  if (s == NULL) {
+    return (POK_ERRNO_EINVAL);
+  }
+  
   for (size_t i = 0; i < length; i++) {
     /* Wait for receive data register to have data */
     while (!(USART1_SR & USART_SR_RXNE)) {

--- a/kernel/arch/arm/stm32f4/cons.c
+++ b/kernel/arch/arm/stm32f4/cons.c
@@ -67,7 +67,8 @@ pok_ret_t pok_cons_init(void) {
   
   /* Configure USART1 */
   /* Assuming 16MHz clock, set baud rate to 115200 */
-  USART1_BRR = 16000000 / 115200;
+  /* BRR = fck / (16 * baud_rate) for oversampling by 16 */
+  USART1_BRR = 16000000 / (16 * 115200);
   
   /* Enable USART, transmitter, and receiver */
   USART1_CR1 = USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;

--- a/kernel/arch/arm/stm32f4/startup.S
+++ b/kernel/arch/arm/stm32f4/startup.S
@@ -30,7 +30,7 @@ stack_mem:
 .equ    __StackTop, stack_mem + Stack_Size
 
 /* Vector table */
-.section ".vectors", "a"
+.section ".isr_vector", "a"
 .align 2
 .globl vector_table
 vector_table:
@@ -69,14 +69,14 @@ Reset_Handler:
     mov sp, r0
     
     /* Initialize data section */
-    ldr r0, =__data_start__
-    ldr r1, =__data_end__
-    ldr r2, =__data_load__
+    ldr r0, =_sdata
+    ldr r1, =_edata
+    ldr r2, =_sidata
     bl  copy_data
     
     /* Initialize BSS section */
-    ldr r0, =__bss_start__
-    ldr r1, =__bss_end__
+    ldr r0, =_sbss
+    ldr r1, =_ebss
     bl  clear_bss
     
     /* Call main POK kernel initialization */
@@ -88,28 +88,28 @@ hang:
 
 /* Copy data section from flash to RAM */
 copy_data:
-    subs r1, r1, r0        /* Calculate size */
-    ble copy_data_done     /* If size <= 0, skip */
+    cmp r0, r1            /* Compare start and end */
+    bge copy_data_done    /* If start >= end, skip */
 copy_data_loop:
     ldr r3, [r2]          /* Load from flash */
     str r3, [r0]          /* Store to RAM */
     adds r0, r0, #4       /* Increment RAM pointer */
     adds r2, r2, #4       /* Increment flash pointer */
-    subs r1, r1, #4       /* Decrement size */
-    bgt copy_data_loop    /* Continue if size > 0 */
+    cmp r0, r1            /* Compare with end address */
+    blt copy_data_loop    /* Continue if not at end */
 copy_data_done:
     bx lr
 
 /* Clear BSS section */
 clear_bss:
     movs r2, #0           /* Clear value */
-    subs r1, r1, r0       /* Calculate size */
-    ble clear_bss_done    /* If size <= 0, skip */
+    cmp r0, r1            /* Compare start and end */
+    bge clear_bss_done    /* If start >= end, skip */
 clear_bss_loop:
     str r2, [r0]          /* Clear word */
     adds r0, r0, #4       /* Increment pointer */
-    subs r1, r1, #4       /* Decrement size */
-    bgt clear_bss_loop    /* Continue if size > 0 */
+    cmp r0, r1            /* Compare with end address */
+    blt clear_bss_loop    /* Continue if not at end */
 clear_bss_done:
     bx lr
 

--- a/kernel/arch/arm/stm32f4/startup.S
+++ b/kernel/arch/arm/stm32f4/startup.S
@@ -1,0 +1,150 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/stm32f4/startup.S
+ * \author  POK team  
+ * \brief   STM32F4 startup code and vector table
+ */
+
+.syntax unified
+.cpu cortex-m3
+.thumb
+
+/* Stack top (end of RAM) */
+.equ    Stack_Size, 0x1000
+.section ".stack"
+stack_mem:
+.space  Stack_Size
+.equ    __StackTop, stack_mem + Stack_Size
+
+/* Vector table */
+.section ".vectors", "a"
+.align 2
+.globl vector_table
+vector_table:
+    .word   __StackTop                  /* Initial Stack Pointer */
+    .word   Reset_Handler               /* Reset Handler */
+    .word   NMI_Handler                 /* NMI Handler */
+    .word   HardFault_Handler           /* Hard Fault Handler */
+    .word   MemManage_Handler           /* Memory Management Fault Handler */
+    .word   BusFault_Handler            /* Bus Fault Handler */
+    .word   UsageFault_Handler          /* Usage Fault Handler */
+    .word   0                           /* Reserved */
+    .word   0                           /* Reserved */
+    .word   0                           /* Reserved */
+    .word   0                           /* Reserved */
+    .word   SVC_Handler                 /* SVCall Handler */
+    .word   DebugMon_Handler            /* Debug Monitor Handler */
+    .word   0                           /* Reserved */
+    .word   PendSV_Handler              /* PendSV Handler */
+    .word   SysTick_Handler             /* SysTick Handler */
+    
+    /* External interrupts (STM32F4 specific) */
+    .rept   82
+    .word   Default_Handler             /* External interrupt handlers */
+    .endr
+
+.text
+.thumb
+.align 2
+
+/* Reset handler */
+.globl Reset_Handler
+.type Reset_Handler, %function
+Reset_Handler:
+    /* Set stack pointer */
+    ldr r0, =__StackTop
+    mov sp, r0
+    
+    /* Initialize data section */
+    ldr r0, =__data_start__
+    ldr r1, =__data_end__
+    ldr r2, =__data_load__
+    bl  copy_data
+    
+    /* Initialize BSS section */
+    ldr r0, =__bss_start__
+    ldr r1, =__bss_end__
+    bl  clear_bss
+    
+    /* Call main POK kernel initialization */
+    bl  pok_boot
+    
+    /* Should never reach here */
+hang:
+    b   hang
+
+/* Copy data section from flash to RAM */
+copy_data:
+    subs r1, r1, r0        /* Calculate size */
+    ble copy_data_done     /* If size <= 0, skip */
+copy_data_loop:
+    ldr r3, [r2]          /* Load from flash */
+    str r3, [r0]          /* Store to RAM */
+    adds r0, r0, #4       /* Increment RAM pointer */
+    adds r2, r2, #4       /* Increment flash pointer */
+    subs r1, r1, #4       /* Decrement size */
+    bgt copy_data_loop    /* Continue if size > 0 */
+copy_data_done:
+    bx lr
+
+/* Clear BSS section */
+clear_bss:
+    movs r2, #0           /* Clear value */
+    subs r1, r1, r0       /* Calculate size */
+    ble clear_bss_done    /* If size <= 0, skip */
+clear_bss_loop:
+    str r2, [r0]          /* Clear word */
+    adds r0, r0, #4       /* Increment pointer */
+    subs r1, r1, #4       /* Decrement size */
+    bgt clear_bss_loop    /* Continue if size > 0 */
+clear_bss_done:
+    bx lr
+
+/* Default handler for unused interrupts */
+.globl Default_Handler
+.type Default_Handler, %function
+Default_Handler:
+    b Default_Handler
+
+/* Weak aliases for exception handlers */
+.weak NMI_Handler
+.thumb_set NMI_Handler, Default_Handler
+
+.weak HardFault_Handler  
+.thumb_set HardFault_Handler, Default_Handler
+
+.weak MemManage_Handler
+.thumb_set MemManage_Handler, Default_Handler
+
+.weak BusFault_Handler
+.thumb_set BusFault_Handler, Default_Handler
+
+.weak UsageFault_Handler
+.thumb_set UsageFault_Handler, Default_Handler
+
+.weak SVC_Handler
+.thumb_set SVC_Handler, Default_Handler
+
+.weak DebugMon_Handler
+.thumb_set DebugMon_Handler, Default_Handler
+
+.weak PendSV_Handler
+.thumb_set PendSV_Handler, Default_Handler
+
+.weak SysTick_Handler
+.thumb_set SysTick_Handler, Default_Handler
+
+.end

--- a/kernel/arch/arm/stm32f4/stm32f4.ld
+++ b/kernel/arch/arm/stm32f4/stm32f4.ld
@@ -1,0 +1,98 @@
+/*
+ * STM32F4 Linker Script for POK ARM Cortex-M port
+ * Memory layout for STM32F407VG (1MB Flash, 128KB SRAM)
+ */
+
+ENTRY(Reset_Handler)
+
+/* Memory layout */
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 1024K
+  SRAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+/* Stack size definitions */
+_stack_size = 0x400;  /* 1KB stack */
+
+SECTIONS
+{
+  /* Vector table goes to flash */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))
+    . = ALIGN(4);
+  } >FLASH
+
+  /* Program code and constants */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)
+    *(.text*)
+    *(.rodata)
+    *(.rodata*)
+    . = ALIGN(4);
+    _etext = .;
+  } >FLASH
+
+  /* ARM exception unwinding */
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } >FLASH
+  
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  /* Initialized data (copied from flash to RAM at startup) */
+  .data : 
+  {
+    . = ALIGN(4);
+    _sdata = .;
+    *(.data)
+    *(.data*)
+    . = ALIGN(4);
+    _edata = .;
+  } >SRAM AT >FLASH
+  
+  _sidata = LOADADDR(.data);
+
+  /* Uninitialized data (zero-initialized) */
+  .bss :
+  {
+    . = ALIGN(4);
+    _sbss = .;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    _ebss = .;
+  } >SRAM
+
+  /* Stack (grows downward from top of SRAM) */
+  .stack :
+  {
+    . = ALIGN(8);
+    . = . + _stack_size;
+    . = ALIGN(8);
+    _estack = .;
+  } >SRAM
+
+  /* Heap (optional, after BSS) */
+  _end = .;
+  PROVIDE(end = .);
+  
+  /* Remove debugging sections */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+}

--- a/kernel/arch/arm/stm32f4/timer.c
+++ b/kernel/arch/arm/stm32f4/timer.c
@@ -1,0 +1,69 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/stm32f4/timer.c
+ * \author  POK team
+ * \brief   STM32F4 system timer using SysTick
+ */
+
+#include <errno.h>
+#include <core/time.h>
+#include "../nvic.h"
+
+/* SysTick registers */
+#define SYSTICK_BASE      0xE000E010
+#define SYSTICK_CSR       (*((volatile uint32_t *)(SYSTICK_BASE + 0x00)))
+#define SYSTICK_RVR       (*((volatile uint32_t *)(SYSTICK_BASE + 0x04)))
+#define SYSTICK_CVR       (*((volatile uint32_t *)(SYSTICK_BASE + 0x08)))
+
+/* SysTick Control and Status Register bits */
+#define SYSTICK_CSR_ENABLE    (1 << 0)
+#define SYSTICK_CSR_TICKINT   (1 << 1)
+#define SYSTICK_CSR_CLKSOURCE (1 << 2)
+
+/* System clock frequency (Hz) - STM32F4 default */
+#define SYSTEM_CLOCK_HZ   16000000
+
+/* Timer tick frequency (100 Hz = 10ms ticks) */
+#define TIMER_TICK_HZ     100
+#define TIMER_RELOAD_VAL  (SYSTEM_CLOCK_HZ / TIMER_TICK_HZ)
+
+pok_ret_t pok_timer_init(void) {
+  /* Disable SysTick */
+  SYSTICK_CSR = 0;
+  
+  /* Set reload value for desired tick rate */
+  SYSTICK_RVR = TIMER_RELOAD_VAL - 1;
+  
+  /* Clear current value */
+  SYSTICK_CVR = 0;
+  
+  /* Configure SysTick: enable, interrupt, use processor clock */
+  SYSTICK_CSR = SYSTICK_CSR_ENABLE | SYSTICK_CSR_TICKINT | SYSTICK_CSR_CLKSOURCE;
+  
+  return (POK_ERRNO_OK);
+}
+
+void pok_timer_handler(void) {
+  /* Clear SysTick interrupt flag (automatically cleared by reading CSR) */
+  (void)SYSTICK_CSR;
+  
+  /* Update POK system time */
+  pok_tick_counter++;
+  
+  /* Trigger scheduler if needed */
+  extern void pok_sched_end_period(void);
+  pok_sched_end_period();
+}

--- a/kernel/arch/arm/stm32f4/timer.c
+++ b/kernel/arch/arm/stm32f4/timer.c
@@ -40,7 +40,25 @@
 #define TIMER_TICK_HZ     100
 #define TIMER_RELOAD_VAL  (SYSTEM_CLOCK_HZ / TIMER_TICK_HZ)
 
+/* SysTick reload register is 24-bit */
+#define SYSTICK_MAX_RELOAD  0xFFFFFF
+
 pok_ret_t pok_timer_init(void) {
+  /* Validate SysTick reload value doesn't exceed 24-bit limit */
+  if (TIMER_RELOAD_VAL > SYSTICK_MAX_RELOAD) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: SysTick reload value %u exceeds 24-bit limit %u\n", 
+           TIMER_RELOAD_VAL, SYSTICK_MAX_RELOAD);
+    printf("Consider reducing SYSTEM_CLOCK_HZ or increasing TIMER_TICK_HZ\n");
+#endif
+    return (POK_ERRNO_EINVAL);
+  }
+
+#ifdef POK_NEEDS_DEBUG
+  printf("SysTick: %u Hz system clock, %u Hz tick rate, reload = %u\n",
+         SYSTEM_CLOCK_HZ, TIMER_TICK_HZ, TIMER_RELOAD_VAL);
+#endif
+
   /* Disable SysTick */
   SYSTICK_CSR = 0;
   

--- a/kernel/arch/arm/stm32f4/timer.c
+++ b/kernel/arch/arm/stm32f4/timer.c
@@ -19,6 +19,7 @@
  */
 
 #include <errno.h>
+#include <libc.h>
 #include <core/time.h>
 #include "../nvic.h"
 

--- a/kernel/arch/arm/syscalls.c
+++ b/kernel/arch/arm/syscalls.c
@@ -49,8 +49,9 @@ void SVC_Handler(void) {
   __asm volatile ("mrs %0, psp" : "=r" (frame));
   
   /* Extract SVC number from the SVC instruction */
-  uint8_t *svc_addr = (uint8_t *)(frame[6] - 2);  /* PC points to instruction after SVC */
-  uint8_t svc_number = svc_addr[0];               /* SVC number is in lower byte */
+  uint16_t *svc_addr = (uint16_t *)(frame[6] - 2); /* PC points to instruction after SVC */
+  uint16_t svc_instruction = *svc_addr;             /* Read the 16-bit SVC instruction */
+  uint8_t svc_number = svc_instruction & 0xFF;     /* SVC number is in lower 8 bits */
   
   /*
    * Set up syscall information

--- a/kernel/arch/arm/syscalls.c
+++ b/kernel/arch/arm/syscalls.c
@@ -27,11 +27,10 @@
 #include "mpu.h"
 
 /* Extract partition ID from current MPU configuration */
-static uint8_t get_current_partition_id(void) {
-  /* In this simple implementation, we track the current partition */
-  /* This could be enhanced to use MPU region information */
+static uint8_t pok_get_current_partition_id(void) {
+  /* TODO: Enhance to derive partition ID from current active MPU region */
   extern uint8_t pok_current_partition;
-  return pok_current_partition;
+  return (pok_current_partition);
 }
 
 /*
@@ -48,15 +47,20 @@ void SVC_Handler(void) {
   /* Get the stack frame from PSP */
   __asm volatile ("mrs %0, psp" : "=r" (frame));
   
+  if (frame == NULL) {
+    return; /* Invalid stack frame */
+  }
+  
   /* Extract SVC number from the SVC instruction */
   uint16_t *svc_addr = (uint16_t *)(frame[6] - 2); /* PC points to instruction after SVC */
   uint16_t svc_instruction = *svc_addr;             /* Read the 16-bit SVC instruction */
   uint8_t svc_number = svc_instruction & 0xFF;     /* SVC number is in lower 8 bits */
+  (void)svc_number;  /* Currently unused - could be used for SVC routing */
   
   /*
    * Set up syscall information
    */
-  syscall_info.partition = get_current_partition_id();
+  syscall_info.partition = pok_get_current_partition_id();
   
   if (syscall_info.partition >= POK_CONFIG_NB_PARTITIONS) {
     syscall_ret = POK_ERRNO_EINVAL;

--- a/kernel/arch/arm/syscalls.c
+++ b/kernel/arch/arm/syscalls.c
@@ -23,8 +23,8 @@
 #include <core/syscall.h>
 #include <errno.h>
 
-#include "nvic.h"
 #include "mpu.h"
+#include "nvic.h"
 
 /* Extract partition ID from current MPU configuration */
 static uint8_t pok_get_current_partition_id(void) {
@@ -43,40 +43,43 @@ void SVC_Handler(void) {
   pok_ret_t syscall_ret;
   pok_syscall_args_t *syscall_args;
   pok_syscall_id_t syscall_id;
-  
+
   /* Get the stack frame from PSP */
-  __asm volatile ("mrs %0, psp" : "=r" (frame));
-  
+  __asm volatile("mrs %0, psp" : "=r"(frame));
+
   if (frame == NULL) {
     return; /* Invalid stack frame */
   }
-  
+
   /* Extract SVC number from the SVC instruction */
-  uint16_t *svc_addr = (uint16_t *)(frame[6] - 2); /* PC points to instruction after SVC */
-  uint16_t svc_instruction = *svc_addr;             /* Read the 16-bit SVC instruction */
-  uint8_t svc_number = svc_instruction & 0xFF;     /* SVC number is in lower 8 bits */
-  (void)svc_number;  /* Currently unused - could be used for SVC routing */
-  
+  uint16_t *svc_addr =
+      (uint16_t *)(frame[6] - 2);       /* PC points to instruction after SVC */
+  uint16_t svc_instruction = *svc_addr; /* Read the 16-bit SVC instruction */
+  uint8_t svc_number =
+      svc_instruction & 0xFF; /* SVC number is in lower 8 bits */
+  (void)svc_number; /* Currently unused - could be used for SVC routing */
+
   /*
    * Set up syscall information
    */
   syscall_info.partition = pok_get_current_partition_id();
-  
+
   if (syscall_info.partition >= POK_CONFIG_NB_PARTITIONS) {
     syscall_ret = POK_ERRNO_EINVAL;
     goto syscall_exit;
   }
-  
+
   syscall_info.base_addr = pok_partitions[syscall_info.partition].base_addr;
   syscall_info.thread = POK_SCHED_CURRENT_THREAD;
-  
-  /* 
+
+  /*
    * Get syscall arguments from registers
    * r0 = syscall_id, r1 = syscall_args pointer
    */
-  syscall_id = (pok_syscall_id_t)frame[0];  /* r0 */
-  syscall_args = (pok_syscall_args_t *)(frame[1] + syscall_info.base_addr);  /* r1 */
-  
+  syscall_id = (pok_syscall_id_t)frame[0]; /* r0 */
+  syscall_args =
+      (pok_syscall_args_t *)(frame[1] + syscall_info.base_addr); /* r1 */
+
   /*
    * Validate that the arguments pointer is within partition bounds
    */
@@ -85,12 +88,12 @@ void SVC_Handler(void) {
     syscall_ret = POK_ERRNO_EINVAL;
     goto syscall_exit;
   }
-  
+
   /*
    * Execute the system call
    */
   syscall_ret = pok_core_syscall(syscall_id, syscall_args, &syscall_info);
-  
+
 syscall_exit:
   /*
    * Return the result in r0
@@ -106,35 +109,38 @@ void __attribute__((naked)) PendSV_Handler(void) {
   /* Access global variables from thread.c */
   extern uint32_t *g_old_sp_ptr;
   extern uint32_t g_new_sp;
-  
-  __asm volatile (
-    /* Save current thread context */
-    "mrs r0, psp                \n"  /* Get current Process Stack Pointer */
-    "cbz r0, 1f                 \n"  /* Skip if PSP is NULL (first time) */
-    
-    "stmdb r0!, {r4-r11}        \n"  /* Save r4-r11 (caller-saved regs) to stack */
-    
-    /* Store updated PSP to old thread's stack pointer */
-    "ldr r1, =g_old_sp_ptr      \n"  /* Load address of g_old_sp_ptr */
-    "ldr r1, [r1]               \n"  /* Load g_old_sp_ptr value */
-    "cbz r1, 1f                 \n"  /* Skip if NULL */
-    "str r0, [r1]               \n"  /* Store new PSP value */
-    
-    "1:                         \n"  /* Load new thread context */
-    "ldr r0, =g_new_sp          \n"  /* Load address of g_new_sp */
-    "ldr r0, [r0]               \n"  /* Load g_new_sp value */
-    "cbz r0, 2f                 \n"  /* Skip if NULL */
-    
-    "ldmia r0!, {r4-r11}        \n"  /* Restore r4-r11 from new thread's stack */
-    "msr psp, r0                \n"  /* Set new Process Stack Pointer */
-    
-    "2:                         \n"
-    /* Ensure thread mode with PSP */
-    "ldr r0, =0xFFFFFFFD        \n"  /* EXC_RETURN: Return to Thread, use PSP */
-    "bx r0                      \n"  /* Return from exception */
-    
-    ::: "memory"
-  );
+
+  __asm volatile(
+      /* Save current thread context */
+      "mrs r0, psp                \n" /* Get current Process Stack Pointer */
+      "cbz r0, 1f                 \n" /* Skip if PSP is NULL (first time) */
+
+      "stmdb r0!, {r4-r11}        \n" /* Save r4-r11 (caller-saved regs) to
+                                         stack */
+
+      /* Store updated PSP to old thread's stack pointer */
+      "ldr r1, =g_old_sp_ptr      \n" /* Load address of g_old_sp_ptr */
+      "ldr r1, [r1]               \n" /* Load g_old_sp_ptr value */
+      "cbz r1, 1f                 \n" /* Skip if NULL */
+      "str r0, [r1]               \n" /* Store new PSP value */
+
+      "1:                         \n" /* Load new thread context */
+      "ldr r0, =g_new_sp          \n" /* Load address of g_new_sp */
+      "ldr r0, [r0]               \n" /* Load g_new_sp value */
+      "cbz r0, 2f                 \n" /* Skip if NULL */
+
+      "ldmia r0!, {r4-r11}        \n" /* Restore r4-r11 from new thread's stack
+                                       */
+      "msr psp, r0                \n" /* Set new Process Stack Pointer */
+
+      "2:                         \n"
+      /* Ensure thread mode with PSP */
+      "ldr r0, =0xFFFFFFFD        \n" /* EXC_RETURN: Return to Thread, use PSP
+                                       */
+      "bx r0                      \n" /* Return from exception */
+
+      ::
+          : "memory");
 }
 
 /*
@@ -154,6 +160,6 @@ pok_ret_t pok_syscall_init(void) {
   /* Set up PendSV for context switching */
   pok_nvic_set_handler(EXCEPTION_PENDSV, PendSV_Handler);
   pok_nvic_set_priority(EXCEPTION_PENDSV, NVIC_PRIORITY_LOWEST);
-  
+
   return (POK_ERRNO_OK);
 }

--- a/kernel/arch/arm/syscalls.c
+++ b/kernel/arch/arm/syscalls.c
@@ -100,15 +100,40 @@ syscall_exit:
 
 /*
  * PendSV Handler - handles context switches
+ * This is called when pok_context_switch() triggers the PendSV exception
  */
-void PendSV_Handler(void) {
-  /* Context switching is handled by the scheduler */
-  /* This handler completes the context switch initiated by pok_context_switch */
+void __attribute__((naked)) PendSV_Handler(void) {
+  /* Access global variables from thread.c */
+  extern uint32_t *g_old_sp_ptr;
+  extern uint32_t g_new_sp;
   
   __asm volatile (
-    /* Context switch is already prepared by pok_context_switch */
-    /* Just return to continue with new context */
-    "bx lr"
+    /* Save current thread context */
+    "mrs r0, psp                \n"  /* Get current Process Stack Pointer */
+    "cbz r0, 1f                 \n"  /* Skip if PSP is NULL (first time) */
+    
+    "stmdb r0!, {r4-r11}        \n"  /* Save r4-r11 (caller-saved regs) to stack */
+    
+    /* Store updated PSP to old thread's stack pointer */
+    "ldr r1, =g_old_sp_ptr      \n"  /* Load address of g_old_sp_ptr */
+    "ldr r1, [r1]               \n"  /* Load g_old_sp_ptr value */
+    "cbz r1, 1f                 \n"  /* Skip if NULL */
+    "str r0, [r1]               \n"  /* Store new PSP value */
+    
+    "1:                         \n"  /* Load new thread context */
+    "ldr r0, =g_new_sp          \n"  /* Load address of g_new_sp */
+    "ldr r0, [r0]               \n"  /* Load g_new_sp value */
+    "cbz r0, 2f                 \n"  /* Skip if NULL */
+    
+    "ldmia r0!, {r4-r11}        \n"  /* Restore r4-r11 from new thread's stack */
+    "msr psp, r0                \n"  /* Set new Process Stack Pointer */
+    
+    "2:                         \n"
+    /* Ensure thread mode with PSP */
+    "ldr r0, =0xFFFFFFFD        \n"  /* EXC_RETURN: Return to Thread, use PSP */
+    "bx r0                      \n"  /* Return from exception */
+    
+    ::: "memory"
   );
 }
 

--- a/kernel/arch/arm/syscalls.c
+++ b/kernel/arch/arm/syscalls.c
@@ -1,0 +1,129 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file kernel/arch/arm/syscalls.c
+ * \brief ARM Cortex-M system call implementation using SVC
+ * \author POK team
+ */
+
+#include <core/debug.h>
+#include <core/partition.h>
+#include <core/syscall.h>
+#include <errno.h>
+
+#include "nvic.h"
+#include "mpu.h"
+
+/* Extract partition ID from current MPU configuration */
+static uint8_t get_current_partition_id(void) {
+  /* In this simple implementation, we track the current partition */
+  /* This could be enhanced to use MPU region information */
+  extern uint8_t pok_current_partition;
+  return pok_current_partition;
+}
+
+/*
+ * SVC Handler - handles system calls
+ * The SVC number and arguments are passed via registers
+ */
+void SVC_Handler(void) {
+  uint32_t *frame;
+  pok_syscall_info_t syscall_info;
+  pok_ret_t syscall_ret;
+  pok_syscall_args_t *syscall_args;
+  pok_syscall_id_t syscall_id;
+  
+  /* Get the stack frame from PSP */
+  __asm volatile ("mrs %0, psp" : "=r" (frame));
+  
+  /* Extract SVC number from the SVC instruction */
+  uint8_t *svc_addr = (uint8_t *)(frame[6] - 2);  /* PC points to instruction after SVC */
+  uint8_t svc_number = svc_addr[0];               /* SVC number is in lower byte */
+  
+  /*
+   * Set up syscall information
+   */
+  syscall_info.partition = get_current_partition_id();
+  
+  if (syscall_info.partition >= POK_CONFIG_NB_PARTITIONS) {
+    syscall_ret = POK_ERRNO_EINVAL;
+    goto syscall_exit;
+  }
+  
+  syscall_info.base_addr = pok_partitions[syscall_info.partition].base_addr;
+  syscall_info.thread = POK_SCHED_CURRENT_THREAD;
+  
+  /* 
+   * Get syscall arguments from registers
+   * r0 = syscall_id, r1 = syscall_args pointer
+   */
+  syscall_id = (pok_syscall_id_t)frame[0];  /* r0 */
+  syscall_args = (pok_syscall_args_t *)(frame[1] + syscall_info.base_addr);  /* r1 */
+  
+  /*
+   * Validate that the arguments pointer is within partition bounds
+   */
+  if (pok_check_ptr_in_partition(syscall_info.partition, (void *)frame[1],
+                                 sizeof(pok_syscall_args_t)) == 0) {
+    syscall_ret = POK_ERRNO_EINVAL;
+    goto syscall_exit;
+  }
+  
+  /*
+   * Execute the system call
+   */
+  syscall_ret = pok_core_syscall(syscall_id, syscall_args, &syscall_info);
+  
+syscall_exit:
+  /*
+   * Return the result in r0
+   */
+  frame[0] = (uint32_t)syscall_ret;
+}
+
+/*
+ * PendSV Handler - handles context switches
+ */
+void PendSV_Handler(void) {
+  /* Context switching is handled by the scheduler */
+  /* This handler completes the context switch initiated by pok_context_switch */
+  
+  __asm volatile (
+    /* Context switch is already prepared by pok_context_switch */
+    /* Just return to continue with new context */
+    "bx lr"
+  );
+}
+
+/*
+ * SysTick Handler - system timer
+ */
+void SysTick_Handler(void) {
+  /* Forward to generic POK timer handler */
+  extern void pok_timer_handler(void);
+  pok_timer_handler();
+}
+
+/**
+ * Initialize system call handling
+ */
+pok_ret_t pok_syscall_init(void) {
+  /* SVC handler is already set in vector table */
+  /* Set up PendSV for context switching */
+  pok_nvic_set_handler(EXCEPTION_PENDSV, PendSV_Handler);
+  pok_nvic_set_priority(EXCEPTION_PENDSV, NVIC_PRIORITY_LOWEST);
+  
+  return (POK_ERRNO_OK);
+}

--- a/kernel/arch/arm/thread.c
+++ b/kernel/arch/arm/thread.c
@@ -78,10 +78,12 @@ void pok_context_switch(uint32_t *old_sp, uint32_t new_sp) {
     "ldr r2, =0xE000ED04        \n"  /* SCB->ICSR */
     "ldr r3, =0x10000000        \n"  /* PENDSVSET bit */
     "str r3, [r2]               \n"  /* Trigger PendSV */
+    "dsb                        \n"  /* Data synchronization barrier */
+    "isb                        \n"  /* Instruction synchronization barrier */
     
-    : /* no output */
-    : "r" (old_sp), "r" (new_sp)
-    : "r2", "r3", "memory"
+    : "=m" (*old_sp)                 /* Output: old_sp is written to */
+    : "r" (new_sp), "m" (*old_sp)    /* Input: new_sp and old_sp memory */
+    : "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "memory"
   );
 }
 

--- a/kernel/arch/arm/thread.c
+++ b/kernel/arch/arm/thread.c
@@ -24,6 +24,7 @@
 #include <libc.h>
 
 #include "thread.h"
+#include "nvic.h"
 
 #define STACK_ALIGNMENT 8
 #define STACK_ALIGNMENT_MASK 0x7u
@@ -64,13 +65,18 @@ uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
   return ((uint32_t)sp);
 }
 
+/* Global variables for PendSV context switching - accessed by PendSV handler */
+uint32_t *g_old_sp_ptr = NULL;
+uint32_t g_new_sp = 0;
+
 /**
  * Perform ARM Cortex-M context switch between threads
  * 
- * Saves current thread context (r4-r11) and loads new thread context.
- * Uses PendSV exception for atomic context switching.
+ * Uses PendSV exception for proper atomic context switching.
+ * This function sets up the context switch parameters and triggers PendSV.
+ * The actual context switch happens in the PendSV handler.
  * 
- * @param old_sp Pointer to store current thread's stack pointer
+ * @param old_sp Pointer to store current thread's stack pointer  
  * @param new_sp Stack pointer of thread to switch to
  */
 void pok_context_switch(uint32_t *old_sp, uint32_t new_sp) {
@@ -78,36 +84,18 @@ void pok_context_switch(uint32_t *old_sp, uint32_t new_sp) {
     return;
   }
   
-  __asm volatile (
-    /* Disable interrupts */
-    "cpsid i                    \n"
-    
-    /* Save current context */
-    "mrs r2, psp                \n"  /* Get current PSP */
-    "stmdb r2!, {r4-r11}        \n"  /* Save r4-r11 to stack */
-    "str r2, [%1]               \n"  /* Store new PSP to old_sp */
-    
-    /* Load new context */
-    "mov r2, %0                 \n"  /* Load new PSP */
-    "ldmia r2!, {r4-r11}        \n"  /* Restore r4-r11 from stack */
-    "msr psp, r2                \n"  /* Set new PSP */
-    
-    /* Re-enable interrupts */
-    "cpsie i                    \n"
-    
-    /* Trigger PendSV to complete context switch */
-    "ldr r2, =0xE000ED04        \n"  /* SCB->ICSR */
-    "ldr r3, =0x10000000        \n"  /* PENDSVSET bit */
-    "str r3, [r2]               \n"  /* Trigger PendSV */
-    "dsb                        \n"  /* Data synchronization barrier */
-    "isb                        \n"  /* Instruction synchronization barrier */
-    
-    :                                /* No outputs */
-    : "r" (new_sp), "r" (old_sp)     /* Input: new_sp register and old_sp pointer */
-    : "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "memory"
-  );
+  /* Set up context switch parameters for PendSV handler */
+  g_old_sp_ptr = old_sp;
+  g_new_sp = new_sp;
   
-  /* Note: The actual value storage happens in the assembly above */
+  /* Ensure memory operations complete before triggering PendSV */
+  __asm volatile ("dsb" ::: "memory");
+  
+  /* Trigger PendSV exception to perform context switch */
+  SCB_ICSR |= SCB_ICSR_PENDSVSET;
+  
+  /* Memory barrier to ensure PendSV is triggered */
+  __asm volatile ("dsb; isb" ::: "memory");
 }
 
 void pok_context_reset(uint32_t stack_size, uint32_t stack_addr) {

--- a/kernel/arch/arm/thread.c
+++ b/kernel/arch/arm/thread.c
@@ -1,0 +1,131 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    thread.c
+ * \brief   ARM Cortex-M thread management and context switching
+ * \author  POK team
+ */
+
+#include <bsp.h>
+#include <core/thread.h>
+#include <errno.h>
+#include <libc.h>
+
+#include "thread.h"
+
+uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
+                            uint32_t entry) {
+  start_context_t *sp;
+  char *stack_addr;
+
+  stack_addr = pok_bsp_mem_alloc(stack_size);
+  if (!stack_addr) {
+    return 0;
+  }
+
+  /* Place context at top of stack */
+  sp = (start_context_t *)(stack_addr + stack_size - sizeof(start_context_t));
+
+  memset(sp, 0, sizeof(start_context_t));
+
+  /* Initialize context for thread startup */
+  sp->ctx.pc = (uint32_t)pok_thread_start;  /* Start with thread wrapper */
+  sp->ctx.lr = 0xFFFFFFFD;                  /* Return to Thread mode, use PSP */
+  sp->ctx.xpsr = 0x01000000;                /* Thumb bit set */
+  sp->ctx.sp = (uint32_t)stack_addr + stack_size - 8;  /* User stack pointer */
+  
+  sp->entry = entry;
+  sp->id = thread_id;
+
+  return ((uint32_t)sp);
+}
+
+/*
+ * Context switch implementation using PendSV exception
+ * This is written in inline assembly to have precise control over register usage
+ */
+void pok_context_switch(uint32_t *old_sp, uint32_t new_sp) {
+  __asm volatile (
+    /* Disable interrupts */
+    "cpsid i                    \n"
+    
+    /* Save current context */
+    "mrs r2, psp                \n"  /* Get current PSP */
+    "stmdb r2!, {r4-r11}        \n"  /* Save r4-r11 to stack */
+    "str r2, [%0]               \n"  /* Store new PSP to old_sp */
+    
+    /* Load new context */
+    "mov r2, %1                 \n"  /* Load new PSP */
+    "ldmia r2!, {r4-r11}        \n"  /* Restore r4-r11 from stack */
+    "msr psp, r2                \n"  /* Set new PSP */
+    
+    /* Re-enable interrupts */
+    "cpsie i                    \n"
+    
+    /* Trigger PendSV to complete context switch */
+    "ldr r2, =0xE000ED04        \n"  /* SCB->ICSR */
+    "ldr r3, =0x10000000        \n"  /* PENDSVSET bit */
+    "str r3, [r2]               \n"  /* Trigger PendSV */
+    
+    : /* no output */
+    : "r" (old_sp), "r" (new_sp)
+    : "r2", "r3", "memory"
+  );
+}
+
+void pok_context_reset(uint32_t stack_size, uint32_t stack_addr) {
+  start_context_t *sp;
+  uint32_t id;
+  uint32_t entry;
+
+  sp = (start_context_t *)(stack_addr + stack_size - sizeof(start_context_t));
+
+  /* Preserve thread information */
+  id = sp->id;
+  entry = sp->entry;
+  
+  /* Reset context */
+  memset(sp, 0, sizeof(start_context_t));
+  
+  sp->ctx.pc = (uint32_t)pok_thread_start;
+  sp->ctx.lr = 0xFFFFFFFD;
+  sp->ctx.xpsr = 0x01000000;
+  sp->ctx.sp = stack_addr + stack_size - 8;
+  
+  sp->entry = entry;
+  sp->id = id;
+}
+
+/*
+ * Thread startup wrapper
+ * This function is called when a new thread starts execution
+ */
+void pok_thread_start(void) {
+  start_context_t *ctx;
+  uint32_t entry, thread_id;
+  
+  /* Get current context from PSP */
+  __asm volatile ("mrs %0, psp" : "=r" (ctx));
+  
+  /* Extract thread information */
+  entry = ctx->entry;
+  thread_id = ctx->id;
+  
+  /* Call the actual thread entry point */
+  ((void (*)(void))entry)();
+  
+  /* Thread should never return, but if it does, terminate it */
+  pok_thread_stop_self();
+}

--- a/kernel/arch/arm/thread.c
+++ b/kernel/arch/arm/thread.c
@@ -44,7 +44,8 @@ uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
   sp->ctx.pc = (uint32_t)pok_thread_start;  /* Start with thread wrapper */
   sp->ctx.lr = 0xFFFFFFFD;                  /* Return to Thread mode, use PSP */
   sp->ctx.xpsr = 0x01000000;                /* Thumb bit set */
-  sp->ctx.sp = (uint32_t)stack_addr + stack_size - 8;  /* User stack pointer */
+  /* Ensure 8-byte aligned stack pointer */
+  sp->ctx.sp = ((uint32_t)stack_addr + stack_size - 8) & ~0x7u;
   
   sp->entry = entry;
   sp->id = thread_id;

--- a/kernel/arch/arm/thread.c
+++ b/kernel/arch/arm/thread.c
@@ -25,6 +25,17 @@
 
 #include "thread.h"
 
+#define STACK_ALIGNMENT 8
+#define STACK_ALIGNMENT_MASK 0x7u
+
+/**
+ * Create a thread context with proper ARM Cortex-M stack frame
+ * 
+ * @param thread_id Unique identifier for the thread
+ * @param stack_size Size of stack to allocate in bytes
+ * @param entry Entry point function address for the thread
+ * @return Context pointer on success, 0 on failure
+ */
 uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
                             uint32_t entry) {
   start_context_t *sp;
@@ -32,7 +43,7 @@ uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
 
   stack_addr = pok_bsp_mem_alloc(stack_size);
   if (!stack_addr) {
-    return 0;
+    return (0);
   }
 
   /* Place context at top of stack */
@@ -41,11 +52,11 @@ uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
   memset(sp, 0, sizeof(start_context_t));
 
   /* Initialize context for thread startup */
-  sp->ctx.pc = (uint32_t)pok_thread_start;  /* Start with thread wrapper */
+  sp->ctx.pc = (uint32_t)pok_arch_thread_start;  /* Start with thread wrapper */
   sp->ctx.lr = 0xFFFFFFFD;                  /* Return to Thread mode, use PSP */
   sp->ctx.xpsr = 0x01000000;                /* Thumb bit set */
   /* Ensure 8-byte aligned stack pointer */
-  sp->ctx.sp = ((uint32_t)stack_addr + stack_size - 8) & ~0x7u;
+  sp->ctx.sp = ((uint32_t)stack_addr + stack_size - STACK_ALIGNMENT) & ~STACK_ALIGNMENT_MASK;
   
   sp->entry = entry;
   sp->id = thread_id;
@@ -53,11 +64,20 @@ uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
   return ((uint32_t)sp);
 }
 
-/*
- * Context switch implementation using PendSV exception
- * This is written in inline assembly to have precise control over register usage
+/**
+ * Perform ARM Cortex-M context switch between threads
+ * 
+ * Saves current thread context (r4-r11) and loads new thread context.
+ * Uses PendSV exception for atomic context switching.
+ * 
+ * @param old_sp Pointer to store current thread's stack pointer
+ * @param new_sp Stack pointer of thread to switch to
  */
 void pok_context_switch(uint32_t *old_sp, uint32_t new_sp) {
+  if (old_sp == NULL) {
+    return;
+  }
+  
   __asm volatile (
     /* Disable interrupts */
     "cpsid i                    \n"
@@ -65,10 +85,10 @@ void pok_context_switch(uint32_t *old_sp, uint32_t new_sp) {
     /* Save current context */
     "mrs r2, psp                \n"  /* Get current PSP */
     "stmdb r2!, {r4-r11}        \n"  /* Save r4-r11 to stack */
-    "str r2, [%0]               \n"  /* Store new PSP to old_sp */
+    "str r2, [%1]               \n"  /* Store new PSP to old_sp */
     
     /* Load new context */
-    "mov r2, %1                 \n"  /* Load new PSP */
+    "mov r2, %0                 \n"  /* Load new PSP */
     "ldmia r2!, {r4-r11}        \n"  /* Restore r4-r11 from stack */
     "msr psp, r2                \n"  /* Set new PSP */
     
@@ -82,10 +102,12 @@ void pok_context_switch(uint32_t *old_sp, uint32_t new_sp) {
     "dsb                        \n"  /* Data synchronization barrier */
     "isb                        \n"  /* Instruction synchronization barrier */
     
-    : "=m" (*old_sp)                 /* Output: old_sp is written to */
-    : "r" (new_sp), "m" (*old_sp)    /* Input: new_sp and old_sp memory */
+    :                                /* No outputs */
+    : "r" (new_sp), "r" (old_sp)     /* Input: new_sp register and old_sp pointer */
     : "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "memory"
   );
+  
+  /* Note: The actual value storage happens in the assembly above */
 }
 
 void pok_context_reset(uint32_t stack_size, uint32_t stack_addr) {
@@ -102,10 +124,10 @@ void pok_context_reset(uint32_t stack_size, uint32_t stack_addr) {
   /* Reset context */
   memset(sp, 0, sizeof(start_context_t));
   
-  sp->ctx.pc = (uint32_t)pok_thread_start;
+  sp->ctx.pc = (uint32_t)pok_arch_thread_start;
   sp->ctx.lr = 0xFFFFFFFD;
   sp->ctx.xpsr = 0x01000000;
-  sp->ctx.sp = stack_addr + stack_size - 8;
+  sp->ctx.sp = stack_addr + stack_size - STACK_ALIGNMENT;
   
   sp->entry = entry;
   sp->id = id;
@@ -115,7 +137,7 @@ void pok_context_reset(uint32_t stack_size, uint32_t stack_addr) {
  * Thread startup wrapper
  * This function is called when a new thread starts execution
  */
-void pok_thread_start(void) {
+void pok_arch_thread_start(void) {
   start_context_t *ctx;
   uint32_t entry, thread_id;
   
@@ -126,9 +148,6 @@ void pok_thread_start(void) {
   entry = ctx->entry;
   thread_id = ctx->id;
   
-  /* Call the actual thread entry point */
-  ((void (*)(void))entry)();
-  
-  /* Thread should never return, but if it does, terminate it */
-  pok_thread_stop_self();
+  /* Call POK core thread start function */
+  pok_thread_start((void (*)(void))entry, thread_id);
 }

--- a/kernel/arch/arm/thread.c
+++ b/kernel/arch/arm/thread.c
@@ -23,15 +23,15 @@
 #include <errno.h>
 #include <libc.h>
 
-#include "thread.h"
 #include "nvic.h"
+#include "thread.h"
 
 #define STACK_ALIGNMENT 8
 #define STACK_ALIGNMENT_MASK 0x7u
 
 /**
  * Create a thread context with proper ARM Cortex-M stack frame
- * 
+ *
  * @param thread_id Unique identifier for the thread
  * @param stack_size Size of stack to allocate in bytes
  * @param entry Entry point function address for the thread
@@ -53,12 +53,13 @@ uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
   memset(sp, 0, sizeof(start_context_t));
 
   /* Initialize context for thread startup */
-  sp->ctx.pc = (uint32_t)pok_arch_thread_start;  /* Start with thread wrapper */
-  sp->ctx.lr = 0xFFFFFFFD;                  /* Return to Thread mode, use PSP */
-  sp->ctx.xpsr = 0x01000000;                /* Thumb bit set */
+  sp->ctx.pc = (uint32_t)pok_arch_thread_start; /* Start with thread wrapper */
+  sp->ctx.lr = 0xFFFFFFFD;   /* Return to Thread mode, use PSP */
+  sp->ctx.xpsr = 0x01000000; /* Thumb bit set */
   /* Ensure 8-byte aligned stack pointer */
-  sp->ctx.sp = ((uint32_t)stack_addr + stack_size - STACK_ALIGNMENT) & ~STACK_ALIGNMENT_MASK;
-  
+  sp->ctx.sp = ((uint32_t)stack_addr + stack_size - STACK_ALIGNMENT) &
+               ~STACK_ALIGNMENT_MASK;
+
   sp->entry = entry;
   sp->id = thread_id;
 
@@ -71,31 +72,31 @@ uint32_t g_new_sp = 0;
 
 /**
  * Perform ARM Cortex-M context switch between threads
- * 
+ *
  * Uses PendSV exception for proper atomic context switching.
  * This function sets up the context switch parameters and triggers PendSV.
  * The actual context switch happens in the PendSV handler.
- * 
- * @param old_sp Pointer to store current thread's stack pointer  
+ *
+ * @param old_sp Pointer to store current thread's stack pointer
  * @param new_sp Stack pointer of thread to switch to
  */
 void pok_context_switch(uint32_t *old_sp, uint32_t new_sp) {
   if (old_sp == NULL) {
     return;
   }
-  
+
   /* Set up context switch parameters for PendSV handler */
   g_old_sp_ptr = old_sp;
   g_new_sp = new_sp;
-  
+
   /* Ensure memory operations complete before triggering PendSV */
-  __asm volatile ("dsb" ::: "memory");
-  
+  __asm volatile("dsb" ::: "memory");
+
   /* Trigger PendSV exception to perform context switch */
   SCB_ICSR |= SCB_ICSR_PENDSVSET;
-  
+
   /* Memory barrier to ensure PendSV is triggered */
-  __asm volatile ("dsb; isb" ::: "memory");
+  __asm volatile("dsb; isb" ::: "memory");
 }
 
 void pok_context_reset(uint32_t stack_size, uint32_t stack_addr) {
@@ -108,15 +109,16 @@ void pok_context_reset(uint32_t stack_size, uint32_t stack_addr) {
   /* Preserve thread information */
   id = sp->id;
   entry = sp->entry;
-  
+
   /* Reset context */
   memset(sp, 0, sizeof(start_context_t));
-  
+
   sp->ctx.pc = (uint32_t)pok_arch_thread_start;
   sp->ctx.lr = 0xFFFFFFFD;
   sp->ctx.xpsr = 0x01000000;
-  sp->ctx.sp = stack_addr + stack_size - STACK_ALIGNMENT;
-  
+  /* Ensure 8-byte aligned stack pointer */
+  sp->ctx.sp = ((stack_addr + stack_size - STACK_ALIGNMENT) & ~STACK_ALIGNMENT_MASK);
+
   sp->entry = entry;
   sp->id = id;
 }
@@ -128,14 +130,14 @@ void pok_context_reset(uint32_t stack_size, uint32_t stack_addr) {
 void pok_arch_thread_start(void) {
   start_context_t *ctx;
   uint32_t entry, thread_id;
-  
+
   /* Get current context from PSP */
-  __asm volatile ("mrs %0, psp" : "=r" (ctx));
-  
+  __asm volatile("mrs %0, psp" : "=r"(ctx));
+
   /* Extract thread information */
   entry = ctx->entry;
   thread_id = ctx->id;
-  
+
   /* Call POK core thread start function */
   pok_thread_start((void (*)(void))entry, thread_id);
 }

--- a/kernel/arch/arm/thread.h
+++ b/kernel/arch/arm/thread.h
@@ -1,0 +1,62 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_THREAD_H__
+#define __POK_ARM_THREAD_H__
+
+#include <types.h>
+
+/*
+ * ARM Cortex-M context structure
+ * This represents the CPU state that must be saved/restored during context switches
+ */
+typedef struct {
+  /* Registers saved by hardware on exception entry */
+  uint32_t r0;
+  uint32_t r1; 
+  uint32_t r2;
+  uint32_t r3;
+  uint32_t r12;
+  uint32_t lr;      /* Link register */
+  uint32_t pc;      /* Program counter */
+  uint32_t xpsr;    /* Program status register */
+  
+  /* Registers saved manually by software */
+  uint32_t r4;
+  uint32_t r5;
+  uint32_t r6;
+  uint32_t r7;
+  uint32_t r8;
+  uint32_t r9;
+  uint32_t r10;
+  uint32_t r11;
+  uint32_t sp;      /* Stack pointer (PSP for threads) */
+} context_t;
+
+/*
+ * Thread startup context structure
+ */
+typedef struct {
+  context_t ctx;
+  uint32_t entry;   /* Thread entry point */
+  uint32_t id;      /* Thread ID */
+} start_context_t;
+
+/* Function prototypes */
+uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size, uint32_t entry);
+void pok_context_switch(uint32_t *old_sp, uint32_t new_sp);
+void pok_context_reset(uint32_t stack_size, uint32_t stack_addr);
+void pok_thread_start(void);
+
+#endif /* !__POK_ARM_THREAD_H__ */

--- a/kernel/arch/arm/thread.h
+++ b/kernel/arch/arm/thread.h
@@ -19,19 +19,20 @@
 
 /*
  * ARM Cortex-M context structure
- * This represents the CPU state that must be saved/restored during context switches
+ * This represents the CPU state that must be saved/restored during context
+ * switches
  */
 typedef struct {
   /* Registers saved by hardware on exception entry */
   uint32_t r0;
-  uint32_t r1; 
+  uint32_t r1;
   uint32_t r2;
   uint32_t r3;
   uint32_t r12;
-  uint32_t lr;      /* Link register */
-  uint32_t pc;      /* Program counter */
-  uint32_t xpsr;    /* Program status register */
-  
+  uint32_t lr;   /* Link register */
+  uint32_t pc;   /* Program counter */
+  uint32_t xpsr; /* Program status register */
+
   /* Registers saved manually by software */
   uint32_t r4;
   uint32_t r5;
@@ -41,7 +42,7 @@ typedef struct {
   uint32_t r9;
   uint32_t r10;
   uint32_t r11;
-  uint32_t sp;      /* Stack pointer (PSP for threads) */
+  uint32_t sp; /* Stack pointer (PSP for threads) */
 } context_t;
 
 /*
@@ -49,12 +50,13 @@ typedef struct {
  */
 typedef struct {
   context_t ctx;
-  uint32_t entry;   /* Thread entry point */
-  uint32_t id;      /* Thread ID */
+  uint32_t entry; /* Thread entry point */
+  uint32_t id;    /* Thread ID */
 } start_context_t;
 
 /* Function prototypes */
-uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size, uint32_t entry);
+uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
+                            uint32_t entry);
 void pok_context_switch(uint32_t *old_sp, uint32_t new_sp);
 void pok_context_reset(uint32_t stack_size, uint32_t stack_addr);
 void pok_arch_thread_start(void);

--- a/kernel/arch/arm/thread.h
+++ b/kernel/arch/arm/thread.h
@@ -57,6 +57,6 @@ typedef struct {
 uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size, uint32_t entry);
 void pok_context_switch(uint32_t *old_sp, uint32_t new_sp);
 void pok_context_reset(uint32_t stack_size, uint32_t stack_addr);
-void pok_thread_start(void);
+void pok_arch_thread_start(void);
 
 #endif /* !__POK_ARM_THREAD_H__ */

--- a/kernel/include/arch.h
+++ b/kernel/include/arch.h
@@ -117,4 +117,8 @@ __attribute__((noreturn)) void pok_division_by_zero_error(void);
 #include <arch/sparc/spinlock.h>
 #endif
 
+#ifdef POK_ARCH_ARM
+/* ARM-specific includes can be added here if needed */
+#endif
+
 #endif /* !__POK_ARCH_H__ */

--- a/kernel/include/bsp.h
+++ b/kernel/include/bsp.h
@@ -33,6 +33,11 @@ pok_ret_t pok_bsp_irq_register(uint8_t irq, void (*handler)(void));
 
 void *pok_bsp_mem_alloc(size_t size);
 
+uint32_t pok_bsp_mem_base(void);
+uint32_t pok_bsp_mem_size(void);
+uint32_t pok_bsp_kernel_base(void);
+uint32_t pok_bsp_kernel_size(void);
+
 pok_ret_t pok_bsp_time_init();
 
 bool_t pok_cons_write(const char *s, size_t length);

--- a/misc/conf-env.pl
+++ b/misc/conf-env.pl
@@ -67,6 +67,18 @@ my %tools_common =
  );
 
 my %tools_arch;
+$tools_arch{"arm"} =
+{
+ "AR" 	      =>  ["arm-none-eabi-ar", "arm-elf-ar", "ar"],
+ "CC"          =>  ["arm-none-eabi-gcc", "arm-elf-gcc", "gcc"],
+ "CXX"	      =>  ["arm-none-eabi-g++", "arm-elf-g++", "g++"],
+ "LD"	         =>  ["arm-none-eabi-ld", "arm-elf-ld", "ld"],
+ "OBJDUMP"     =>  ["arm-none-eabi-objdump", "arm-elf-objdump", "objdump"],
+ "OBJCOPY"     =>  ["arm-none-eabi-objcopy", "arm-elf-objcopy", "objcopy"],
+ "RANLIB"      =>  ["arm-none-eabi-ranlib", "arm-elf-ranlib", "ranlib"],
+ "QEMU"        =>  ["qemu-system-arm", "arm-softmmu", "qemu-system-arm"],
+ };
+
 $tools_arch{"x86"} =
 {
  "AR" 	      =>  ["i386-unknown-linux-gnu-ar.exe", "i386-elf-ar" , "ar"],
@@ -403,7 +415,7 @@ my %colors =
 
    my $nb_arch = 0;
 
-   for my $v ("x86", "ppc", "sparc")
+   for my $v ("arm", "x86", "ppc", "sparc")
    {
       
       if (check_arch_tools ($v) == 0)


### PR DESCRIPTION
## Summary by Sourcery

Add ARM Cortex-M architecture support for POK, including interrupt controller, memory protection, context switching, syscalls, BSP drivers, and example usage.

New Features:
- Include ARM in build configuration and arch.h
- Implement NVIC driver for Cortex-M interrupt management
- Provide MPU driver and partition space management via MPU
- Add Cortex-M context creation, context switch, and SVC-based syscall handling
- Introduce exception handlers and startup assembly for STM32F4
- Add STM32F4 BSP with USART console, SysTick timer, and simple memory allocator
- Supply an ARM Cortex-M hello world example with configuration

Build:
- Update kernel arch Makefile to include ARM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full ARM Cortex‑M port: exception/NVIC support, SVC/PendSV syscall path, context switching/threading, MPU-backed partition spaces, and STM32F4 BSP (startup, SysTick timer, USART console, memory allocator, linker script).
  * New STM32F4 example: two‑thread Hello World using partitioned scheduling.

* **Chores**
  * Build/config updated to add ARM architecture, STM32F4 target and toolchain support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->