### PR TITLE
Quick draft: Add cortex-m

### DIFF
--- a/examples/arm-hello/config.yaml
+++ b/examples/arm-hello/config.yaml
@@ -1,0 +1,33 @@
+#                               POK header
+#
+# The following file is a part of the POK project. Any modification should
+# be made according to the POK licence. You CANNOT use this file or a part
+# of a file for your own project.
+#
+# For more information on the POK licence, please see our LICENCE FILE
+#
+# Please follow the coding guidelines described in doc/CODING_GUIDELINES
+#
+#                                      Copyright (c) 2007-2025 POK team
+
+target:
+    arch: arm
+    bsp: stm32f4
+
+partitions:
+    - name: part1
+      features: [assert, console, libc]
+      scheduler: RR
+      threads:
+          count: 2
+          features: [sleep]
+      size: 32kB
+      objects: ["main.o"]
+
+kernel:
+    features: [debug]
+    scheduler:
+        major_frame: 1s
+        slots:
+            - partition: part1
+              duration: 1s

--- a/examples/arm-hello/main.c
+++ b/examples/arm-hello/main.c
@@ -1,0 +1,94 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file examples/arm-hello/main.c
+ * \brief Simple ARM Cortex-M hello world example
+ */
+
+#include <core/partition.h>
+#include <core/thread.h>
+#include <core/time.h>
+#include <libc/stdio.h>
+#include <string.h>
+
+void thread1_job(void) {
+  int i = 0;
+
+  while (1) {
+    printf("Hello from ARM Cortex-M thread 1, iteration %d\n", i++);
+    pok_thread_sleep(1000000); /* Sleep for 1 second */
+  }
+}
+
+void thread2_job(void) {
+  int i = 0;
+
+  while (1) {
+    printf("Hello from ARM Cortex-M thread 2, iteration %d\n", i++);
+    pok_thread_sleep(1500000); /* Sleep for 1.5 seconds */
+  }
+}
+
+static inline void setup_thread_attributes(pok_thread_attr_t *attr,
+                                           void (*func_ptr)(void)) {
+  /* Non-portable hack: copy function pointer bytes to void* since
+   * pok_thread_attr_t.entry is void* but we need to pass function pointers */
+  memcpy(&attr->entry, &func_ptr, sizeof attr->entry);
+  attr->priority = 1;
+  attr->stack_size = 2048;
+  attr->processor_affinity = 0;
+  attr->period = 0;
+  attr->deadline = 0;
+  attr->time_capacity = 0;
+  attr->state = POK_STATE_RUNNABLE;
+}
+
+int main(void) {
+  pok_ret_t ret;
+  uint32_t tid1, tid2;
+  pok_thread_attr_t attr1 = {0}, attr2 = {0};
+
+  printf("POK ARM Cortex-M Hello World Example\n");
+  printf("====================================\n");
+
+  /* Setup first thread attributes */
+  setup_thread_attributes(&attr1, thread1_job);
+
+  /* Create first thread */
+  ret = pok_thread_create(&tid1, &attr1);
+  if (ret != POK_ERRNO_OK) {
+    printf("Error creating thread 1: %d\n", ret);
+    return -1;
+  }
+
+  /* Setup second thread attributes */
+  setup_thread_attributes(&attr2, thread2_job);
+
+  /* Create second thread */
+  ret = pok_thread_create(&tid2, &attr2);
+  if (ret != POK_ERRNO_OK) {
+    printf("Error creating thread 2: %d\n", ret);
+    return -1;
+  }
+
+  printf("Threads created successfully. Starting scheduler...\n");
+
+  /* Start the threads. This call does not return. */
+  pok_partition_set_mode(POK_PARTITION_MODE_NORMAL);
+
+  /* Should never reach here - partition mode change transfers control to
+   * scheduler */
+  __builtin_unreachable();
+}

--- a/kernel/arch/Makefile
+++ b/kernel/arch/Makefile
@@ -6,12 +6,12 @@ include $(TOPDIR)/misc/mk/config.mk
 ifdef ARCH
 SUBDIRS:=$(ARCH)
 else
-SUBDIRS:=ppc sparc x86
+SUBDIRS:=arm ppc sparc x86
 endif
 
 LO_TARGET=	arch.lo
 
-LO_OBJS=		
+LO_OBJS=
 
 LO_DEPS=	$(ARCH)/$(ARCH).lo
 

--- a/kernel/arch/arm/Makefile
+++ b/kernel/arch/arm/Makefile
@@ -1,0 +1,54 @@
+TOPDIR=		../../../
+
+include $(TOPDIR)/misc/mk/config.mk
+-include $(TOPDIR)/misc/mk/common-$(ARCH).mk
+
+LO_TARGET=	arm.lo
+
+LO_OBJS=	arch.o \
+		space.o \
+		thread.o \
+		syscalls.o \
+		exceptions.o \
+		mpu.o \
+		nvic.o
+
+ifdef BSP
+LO_DEPS=	$(BSP)/$(BSP).lo
+endif
+
+include $(TOPDIR)/misc/mk/objdir.mk
+
+all: $(LO_TARGET)
+
+ifdef BSP
+$(LO_TARGET): $(OBJ_DIR)/$(BSP)/$(BSP).lo
+
+$(OBJ_DIR)/$(BSP)/$(BSP).lo::
+	$(CD) $(BSP) && $(MAKE)
+endif
+.PHONY: clean distclean depend all test
+
+clean: common-clean
+ifdef BSP
+	$(CD) $(BSP) && $(MAKE) clean
+endif
+
+distclean: clean
+	$(RM) .depend.mk
+ifdef BSP
+	$(CD) $(BSP) && $(MAKE) distclean
+endif
+
+depend:
+	$(if $(LO_OBJS), $(CC) $(CFLAGS) -MM $(wildcard *.c) $(wildcard *.S) > .depend.mk,)
+ifdef BSP
+	$(CD) $(BSP) && $(MAKE) depend
+endif
+
+# Optional test target for checkmake compliance
+test: all
+	@echo "ARM architecture build test passed"
+
+include $(TOPDIR)/misc/mk/rules-common.mk
+include $(TOPDIR)/misc/mk/rules-kernel.mk

--- a/kernel/arch/arm/arch.c
+++ b/kernel/arch/arm/arch.c
@@ -1,0 +1,152 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/arch.c
+ * \author  POK team
+ * \brief   Provides generic architecture interface for ARM Cortex-M
+ * architecture
+ */
+
+/* POK system headers */
+#include <errno.h>
+
+/* POK core headers */
+#include <arch.h>
+#include <core/partition.h>
+
+/* Architecture-specific headers */
+#include "mpu.h"
+#include "nvic.h"
+
+/* Stack address calculation constants */
+#define POK_STACK_GUARD_BYTES 8 /* Guard offset for stack calculations */
+
+extern pok_ret_t pok_arch_space_init(void);
+
+pok_ret_t pok_arch_init() {
+  pok_ret_t ret;
+
+  ret = pok_mpu_init();
+  if (ret != POK_ERRNO_OK) {
+    return ret;
+  }
+
+  ret = pok_nvic_init();
+  if (ret != POK_ERRNO_OK) {
+    /* Cleanup: disable MPU on NVIC init failure */
+    pok_mpu_disable();
+    return ret;
+  }
+
+  ret = pok_arch_space_init();
+  if (ret != POK_ERRNO_OK) {
+    /* Cleanup: disable MPU on space init failure */
+    /* Note: NVIC cleanup not needed as it doesn't maintain state */
+    pok_mpu_disable();
+    return ret;
+  }
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_arch_preempt_disable() {
+  __asm volatile("cpsid i" : : : "memory");
+  __asm volatile("dsb" : : : "memory");
+  __asm volatile("isb" : : : "memory");
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_arch_preempt_enable() {
+  __asm volatile("cpsie i" : : : "memory");
+  __asm volatile("isb" : : : "memory");
+  return POK_ERRNO_OK;
+}
+
+void pok_arch_idle() __attribute__((noreturn));
+
+void pok_arch_idle() {
+  while (1) {
+    __asm volatile("wfi");
+  }
+}
+
+pok_ret_t pok_arch_event_register(uint8_t vector, void (*handler)(void)) {
+  return (pok_nvic_set_handler(vector, handler));
+}
+
+/**
+ * Calculate stack address for a thread in a partition
+ *
+ * @param partition_id Partition ID (must be < POK_CONFIG_NB_PARTITIONS)
+ * @param local_thread_id Local thread ID within partition
+ * @return Stack address or 0 on invalid input
+ */
+uint32_t pok_thread_stack_addr(const uint8_t partition_id,
+                               const uint32_t local_thread_id) {
+  /* Validate partition_id is within valid range */
+  if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
+    return 0; /* Invalid partition ID */
+  }
+
+  /* Check local_thread_id bounds to prevent overflow */
+  uint32_t partition_size = pok_partitions[partition_id].size;
+  /* Account for guard bytes in max threads calculation */
+  uint32_t effective_stack_size = POK_USER_STACK_SIZE + POK_STACK_GUARD_BYTES;
+  uint32_t max_threads = partition_size / effective_stack_size;
+  if (local_thread_id >= max_threads) {
+    return 0; /* Thread ID too large for partition */
+  }
+
+  /* Use 64-bit arithmetic to prevent overflow */
+  uint64_t stack_offset_64 =
+      (uint64_t)local_thread_id * effective_stack_size + POK_STACK_GUARD_BYTES;
+  if (stack_offset_64 >= partition_size) {
+    return 0; /* Stack offset exceeds partition size */
+  }
+
+  uint32_t stack_offset = (uint32_t)stack_offset_64;
+
+  /* Validate that both stack start and end are within partition bounds */
+  if ((stack_offset + POK_USER_STACK_SIZE) > partition_size) {
+    return 0; /* Invalid stack address - stack extends beyond partition */
+  }
+
+  /* Calculate and return 8-byte aligned stack address */
+  uint32_t partition_base = pok_partitions[partition_id].base_addr;
+  uint32_t stack_addr = partition_base + partition_size - stack_offset;
+
+  /* Ensure 8-byte stack pointer alignment for ARM Cortex-M */
+  return stack_addr & ~7;
+}
+
+/**
+ * Trigger a division by zero error for testing or error handling
+ *
+ * This function intentionally causes a division by zero to test UsageFault
+ * handling when DIV_0_TRP is enabled in the SCB Configuration Control Register.
+ * Used for testing exception handling or as a controlled failure mechanism.
+ *
+ * @note This function never returns
+ */
+__attribute__((noreturn)) void pok_division_by_zero_error(void) {
+  /* Force a division by zero to trigger UsageFault (when DIV_0_TRP enabled) */
+  volatile int zero = 0;
+  volatile int result = 42 / zero;
+  (void)result;
+
+  while (1) {
+    __asm volatile("wfi");
+  }
+}

--- a/kernel/arch/arm/arch.h
+++ b/kernel/arch/arm/arch.h
@@ -1,0 +1,77 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/arch.h
+ * \author  POK team
+ * \brief   ARM Cortex-M architecture constants and definitions
+ */
+
+#ifndef __POK_ARM_ARCH_H__
+#define __POK_ARM_ARCH_H__
+
+/* Required includes for type definitions */
+#include <types.h>
+
+/* ARM Cortex-M Exception Return Values */
+#define ARM_EXC_RETURN_THREAD_PSP                                              \
+  0xFFFFFFFDUL /* Return to Thread mode, use PSP */
+#define ARM_EXC_RETURN_HANDLER_MSP                                             \
+  0xFFFFFFF1UL /* Return to Handler mode, use MSP */
+#define ARM_EXC_RETURN_THREAD_MSP                                              \
+  0xFFFFFFF9UL /* Return to Thread mode, use MSP */
+
+/* ARM Cortex-M Register Bit Masks */
+#define ARM_REGISTER_BYTE_MASK 0xFFu        /* 8-bit register mask */
+#define ARM_REGISTER_WORD_MASK 0xFFFFu      /* 16-bit register mask */
+#define ARM_REGISTER_DWORD_MASK 0xFFFFFFFFu /* 32-bit register mask */
+
+/* Fault Status Register Masks */
+#define ARM_CFSR_MMFSR_MASK 0xFFu      /* MemManage Fault Status [7:0] */
+#define ARM_CFSR_BFSR_MASK 0xFF00u     /* Bus Fault Status [15:8] */
+#define ARM_CFSR_UFSR_MASK 0xFFFF0000u /* Usage Fault Status [31:16] */
+
+/* MPU Region Size Constants */
+#define ARM_MPU_MIN_SUBREGION_SIZE 256 /* Minimum size for subregions */
+#define ARM_MPU_SUBREGION_COUNT 8      /* Number of subregions per region */
+
+/* SVC Instruction Encoding */
+#define ARM_SVC_NUMBER_MASK 0xFF /* SVC number in lower 8 bits */
+
+/* Priority Register Masks with range validation */
+#ifndef ARM_PRIORITY_BITS
+#ifdef __NVIC_PRIO_BITS
+#define ARM_PRIORITY_BITS __NVIC_PRIO_BITS
+#else
+#define ARM_PRIORITY_BITS 4 /* BSP default; override per SoC */
+#endif
+#endif
+
+/* Validate ARM_PRIORITY_BITS is within valid range */
+#if ARM_PRIORITY_BITS < 2 || ARM_PRIORITY_BITS > 8
+#error "ARM_PRIORITY_BITS must be between 2 and 8 inclusive"
+#endif
+
+/* Calculate priority mask based on validated priority bits */
+#define ARM_PRIORITY_MASK ((uint8_t)(0xFFu << (8 - ARM_PRIORITY_BITS)))
+
+/* Priority level constants for validated range */
+#define ARM_PRIORITY_LEVELS (1u << ARM_PRIORITY_BITS)
+#define ARM_MAX_PRIORITY_VALUE (ARM_PRIORITY_LEVELS - 1)
+
+/* Common Magic Values - for reference only, use descriptive names */
+#define ARM_MAGIC_DEAD 0xDEADu /* Debug marker value */
+#define ARM_MAGIC_BEEF 0xBEEFu /* Debug marker value */
+
+#endif /* __POK_ARM_ARCH_H__ */

--- a/kernel/arch/arm/bsp.c
+++ b/kernel/arch/arm/bsp.c
@@ -1,0 +1,5 @@
+/*
+ * Intentionally empty generic ARM BSP placeholder.
+ * Target-specific BSP (e.g., kernel/arch/arm/stm32f4/bsp.c) must provide
+ * pok_bsp_* implementations declared in kernel/include/bsp.h.
+ */

--- a/kernel/arch/arm/cons.c
+++ b/kernel/arch/arm/cons.c
@@ -1,0 +1,36 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/cons.c
+ * \brief   ARM generic console placeholder
+ * \author  POK team
+ *
+ * This file is intentionally minimal as ARM console implementations are
+ * Board Support Package (BSP) specific. Each ARM BSP provides its own
+ * console implementation in arch/arm/<bsp>/cons.c based on the specific
+ * UART/USART hardware available on that platform.
+ *
+ * For example:
+ * - STM32F4 uses USART1 (arch/arm/stm32f4/cons.c)
+ * - Other ARM platforms would implement their specific UART drivers
+ *
+ * The BSP-specific console implementation must provide:
+ * - pok_cons_init(): Initialize UART/console hardware
+ * - pok_cons_write(): Write data to console output
+ * - pok_cons_read(): Read data from console input (if supported)
+ *
+ * This approach allows POK to support diverse ARM microcontrollers and
+ * development boards while maintaining a consistent console interface.
+ */

--- a/kernel/arch/arm/context.h
+++ b/kernel/arch/arm/context.h
@@ -1,0 +1,8 @@
+#ifndef __POK_ARM_CONTEXT_H__
+#define __POK_ARM_CONTEXT_H__
+/*
+ * Reserved for ARM context structures/APIs (see thread.h). Intentionally empty
+ * for now. Add only forward decls and shared definitions to avoid circular
+ * includes.
+ */
+#endif /* __POK_ARM_CONTEXT_H__ */

--- a/kernel/arch/arm/cortex_m_config.h
+++ b/kernel/arch/arm/cortex_m_config.h
@@ -1,0 +1,96 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_CORTEX_M_CONFIG_H__
+#define __POK_ARM_CORTEX_M_CONFIG_H__
+
+/**
+ * \file    arch/arm/cortex_m_config.h
+ * \brief   ARM Cortex-M configuration constants and limits
+ * \author  POK team
+ *
+ * This file centralizes hardware-specific constants for ARM Cortex-M
+ * microcontrollers to make it easier to support different variants.
+ */
+
+/* NVIC (Nested Vectored Interrupt Controller) configuration */
+#ifndef CORTEX_M_NVIC_VECTOR_COUNT
+#define CORTEX_M_NVIC_VECTOR_COUNT                                             \
+  98 /* 16 system + 82 external interrupts for STM32F4 */
+#endif
+
+#define CORTEX_M_NVIC_VECTOR_TABLE_SIZE                                        \
+  (CORTEX_M_NVIC_VECTOR_COUNT * 4) /* Each vector is 4 bytes */
+
+/* Calculate next power-of-two for vector table alignment */
+#ifndef CORTEX_M_NEXT_POW2
+#define CORTEX_M_NEXT_POW2(x) (1U << (32 - __builtin_clz((uint32_t)((x) - 1))))
+#endif
+
+#ifndef CORTEX_M_NVIC_VECTOR_TABLE_ALIGNMENT
+#define CORTEX_M_NVIC_VECTOR_TABLE_ALIGNMENT                                   \
+  CORTEX_M_NEXT_POW2(CORTEX_M_NVIC_VECTOR_TABLE_SIZE)
+#endif
+
+/* Compile-time check: vector table alignment must be >= vector table size */
+_Static_assert(CORTEX_M_NVIC_VECTOR_TABLE_ALIGNMENT >=
+                   CORTEX_M_NVIC_VECTOR_TABLE_SIZE,
+               "Vector table alignment must be at least as large as the vector "
+               "table size");
+/* Compile-time check: vector table alignment must also be a power of two */
+_Static_assert((CORTEX_M_NVIC_VECTOR_TABLE_ALIGNMENT &
+                (CORTEX_M_NVIC_VECTOR_TABLE_ALIGNMENT - 1)) == 0,
+               "Vector table alignment must be a power of two");
+
+/* MPU (Memory Protection Unit) configuration */
+#ifndef CORTEX_M_MPU_MAX_REGIONS
+#define CORTEX_M_MPU_MAX_REGIONS                                               \
+  8 /* Standard Cortex-M3/M4 has 8 MPU regions                                 \
+     */
+#endif
+
+#ifndef CORTEX_M_MPU_MIN_REGION_SIZE
+#define CORTEX_M_MPU_MIN_REGION_SIZE 32 /* Minimum MPU region size in bytes */
+#endif
+
+/* Thread/Stack configuration */
+#ifndef CORTEX_M_STACK_ALIGNMENT
+#define CORTEX_M_STACK_ALIGNMENT                                               \
+  8 /* ARM Cortex-M requires 8-byte stack alignment */
+#endif
+
+#define CORTEX_M_STACK_ALIGNMENT_MASK (CORTEX_M_STACK_ALIGNMENT - 1)
+
+/* Exception priorities (0 = highest, 255 = lowest for Cortex-M3/M4) */
+#ifndef CORTEX_M_PRIORITY_HIGHEST
+#define CORTEX_M_PRIORITY_HIGHEST 0
+#endif
+
+#ifndef CORTEX_M_PRIORITY_HIGH
+#define CORTEX_M_PRIORITY_HIGH 64
+#endif
+
+#ifndef CORTEX_M_PRIORITY_NORMAL
+#define CORTEX_M_PRIORITY_NORMAL 128
+#endif
+
+#ifndef CORTEX_M_PRIORITY_LOW
+#define CORTEX_M_PRIORITY_LOW 192
+#endif
+
+#ifndef CORTEX_M_PRIORITY_LOWEST
+#define CORTEX_M_PRIORITY_LOWEST 255
+#endif
+
+#endif /* !__POK_ARM_CORTEX_M_CONFIG_H__ */

--- a/kernel/arch/arm/exceptions.c
+++ b/kernel/arch/arm/exceptions.c
@@ -1,0 +1,341 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/exceptions.c
+ * \author  POK team
+ * \brief   ARM Cortex-M exception handling
+ */
+
+/* POK system headers */
+#include <errno.h>
+
+/* POK core headers */
+#include <core/debug.h>
+#include <core/partition.h>
+#include <core/sched.h>
+/* Architecture-specific headers */
+#include "arch.h"
+#include "mpu.h"
+#include "nvic.h"
+#include "stm32f4/peripherals.h"
+
+/* STM32F4 USART1 registers for non-blocking fault output */
+#define USART1_SR (*((volatile uint32_t *)(USART1_BASE + 0x00)))
+#define USART1_DR (*((volatile uint32_t *)(USART1_BASE + 0x04)))
+#define USART_SR_TXE (1 << 7) /* Transmit data register empty */
+
+/* Non-blocking fault output functions */
+static inline void fault_putc(char c) {
+  /* Try to output character without blocking */
+  if (USART1_SR & USART_SR_TXE) {
+    USART1_DR = c;
+  }
+}
+
+static void fault_puts(const char *s) {
+  while (*s) {
+    fault_putc(*s++);
+    /* Best-effort only; no delay to avoid prolonging fault handling */
+  }
+}
+
+static void fault_put_hex(uint32_t value) {
+  const char hex_chars[] = "0123456789ABCDEF";
+  fault_puts("0x");
+  for (int i = 28; i >= 0; i -= 4) {
+    fault_putc(hex_chars[(value >> i) & 0xF]);
+  }
+}
+
+static void fault_put_dec(uint32_t value) {
+  char buf[10];
+  int i = 0;
+
+  if (value == 0) {
+    fault_putc('0');
+    return;
+  }
+
+  while (value > 0) {
+    buf[i++] = '0' + (value % 10);
+    value /= 10;
+  }
+
+  /* Print digits in reverse order */
+  while (i > 0) {
+    fault_putc(buf[--i]);
+  }
+}
+
+/* CFSR (Configurable Fault Status Register) bits */
+#define SCB_CFSR (*((volatile uint32_t *)(SCB_BASE + 0x28)))
+#define CFSR_MMARVALID (1 << 7)  /* MemManage Fault Address Register valid */
+#define CFSR_BFARVALID (1 << 15) /* Bus Fault Address Register valid */
+
+/* Forward declarations for the actual handlers */
+static void MemManage_Handler_C(uint32_t *frame);
+static void BusFault_Handler_C(uint32_t *frame);
+static void UsageFault_Handler_C(uint32_t *frame);
+static void HardFault_Handler_C(uint32_t *frame);
+
+/*
+ * Macro to generate naked fault handler wrappers
+ * Determines correct stack pointer (MSP vs PSP) based on EXC_RETURN
+ */
+#define DEFINE_FAULT_HANDLER_WRAPPER(handler_name, c_handler_name)             \
+  void __attribute__((naked)) handler_name(void) {                             \
+    __asm volatile(                                                            \
+        "tst lr, #4                 \n" /* Test EXC_RETURN[2] */               \
+        "ite eq                     \n" /* If-Then-Else */                     \
+        "mrseq r0, msp              \n" /* If EXC_RETURN[2]==0, use MSP */     \
+        "mrsne r0, psp              \n" /* If EXC_RETURN[2]==1, use PSP */     \
+        "b " #c_handler_name                                                   \
+        "      \n" /* Call C handler with correct frame */                     \
+        ::                                                                     \
+            : "r0", "memory");                                                 \
+  }
+
+DEFINE_FAULT_HANDLER_WRAPPER(MemManage_Handler, MemManage_Handler_C)
+
+/*
+ * Memory Management Fault Handler - C implementation
+ * Handles MPU violations and other memory management faults
+ */
+static void MemManage_Handler_C(uint32_t *frame) {
+  uint32_t fault_addr = 0;
+  uint8_t partition_id;
+  uint32_t cfsr;
+
+  if (frame == NULL) {
+    /* Cannot recover from null frame, halt system */
+    __disable_irq(); /* Prevent livelock or nested faults */
+    while (1) {
+      __asm volatile("wfi");
+    }
+  }
+
+  /* Read CFSR to check fault status */
+  cfsr = SCB_CFSR;
+
+  /* Get faulting address from MemManage Fault Address Register if valid */
+  if (cfsr & CFSR_MMARVALID) {
+    fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x34)); /* MMFAR */
+  }
+
+  /* Clear MemManage fault flags in CFSR - write back only set bits */
+  SCB_CFSR = cfsr & ARM_CFSR_MMFSR_MASK; /* Clear only set MMFSR bits */
+
+  /* Get current partition */
+  extern uint8_t pok_current_partition;
+  partition_id = pok_current_partition;
+
+#ifdef POK_NEEDS_DEBUG
+  if (cfsr & CFSR_MMARVALID) {
+    fault_puts("MemManage fault in partition ");
+    fault_put_dec(partition_id);
+    fault_puts(" at address ");
+    fault_put_hex(fault_addr);
+    fault_puts("\n");
+  } else {
+    fault_puts("MemManage fault in partition ");
+    fault_put_dec(partition_id);
+    fault_puts(" (address not available)\n");
+  }
+  fault_puts("PC: ");
+  fault_put_hex(frame[6]);
+  fault_puts(", LR: ");
+  fault_put_hex(frame[5]);
+  fault_puts(", CFSR: ");
+  fault_put_hex(cfsr);
+  fault_puts("\n");
+#endif
+
+  /* For safety-critical systems, halt immediately on memory faults
+   * instead of attempting complex recovery from fault context */
+#ifdef POK_NEEDS_DEBUG
+  fault_puts("FATAL: Memory protection violation in partition ");
+  fault_put_dec(partition_id);
+  fault_puts(" - System halted for safety\n");
+#endif
+
+  /* Halt the system - safer than attempting partition recovery from fault
+   * handler */
+  __disable_irq(); /* Prevent livelock or nested faults */
+  while (1) {
+    __asm volatile("wfi");
+  }
+}
+
+DEFINE_FAULT_HANDLER_WRAPPER(BusFault_Handler, BusFault_Handler_C)
+
+/*
+ * Bus Fault Handler - C implementation
+ * Handles bus errors and invalid memory accesses
+ */
+static void BusFault_Handler_C(uint32_t *frame) {
+  uint32_t fault_addr = 0;
+  uint8_t partition_id;
+  uint32_t cfsr;
+
+  if (frame == NULL) {
+    while (1) {
+      __asm volatile("wfi");
+    }
+  }
+
+  /* Read CFSR to check fault status */
+  cfsr = SCB_CFSR;
+
+  /* Get faulting address from Bus Fault Address Register if valid */
+  if (cfsr & CFSR_BFARVALID) {
+    fault_addr = *((volatile uint32_t *)(SCB_BASE + 0x38)); /* BFAR */
+  }
+
+  /* Clear Bus fault flags in CFSR - write 1 to clear */
+  SCB_CFSR = ARM_CFSR_BFSR_MASK; /* Clear all BFSR bits */
+
+  extern uint8_t pok_current_partition;
+  partition_id = pok_current_partition;
+
+#ifdef POK_NEEDS_DEBUG
+  if (cfsr & CFSR_BFARVALID) {
+    fault_puts("BusFault in partition ");
+    fault_put_dec(partition_id);
+    fault_puts(" at address ");
+    fault_put_hex(fault_addr);
+    fault_puts("\n");
+  } else {
+    fault_puts("BusFault in partition ");
+    fault_put_dec(partition_id);
+    fault_puts(" (address not available)\n");
+  }
+  fault_puts("PC: ");
+  fault_put_hex(frame[6]);
+  fault_puts(", LR: ");
+  fault_put_hex(frame[5]);
+  fault_puts(", CFSR: ");
+  fault_put_hex(cfsr);
+  fault_puts("\n");
+#endif
+
+  /* Halt system immediately - safer than partition recovery from fault context
+   */
+#ifdef POK_NEEDS_DEBUG
+  fault_puts("FATAL: Bus fault recovery disabled - System halted for safety\n");
+#endif
+  __disable_irq(); /* Prevent livelock or nested faults */
+  while (1) {
+    __asm volatile("wfi");
+  }
+}
+
+DEFINE_FAULT_HANDLER_WRAPPER(UsageFault_Handler, UsageFault_Handler_C)
+
+/*
+ * Usage Fault Handler - C implementation
+ * Handles undefined instruction, unaligned access, etc.
+ */
+static void UsageFault_Handler_C(uint32_t *frame) {
+  uint8_t partition_id;
+
+  if (frame == NULL) {
+    while (1) {
+      __asm volatile("wfi");
+    }
+  }
+
+  extern uint8_t pok_current_partition;
+  partition_id = pok_current_partition;
+
+  /* Clear Usage fault flags in CFSR - write 1 to clear */
+  SCB_CFSR = ARM_CFSR_UFSR_MASK; /* Clear all UFSR bits */
+
+#ifdef POK_NEEDS_DEBUG
+  fault_puts("UsageFault in partition ");
+  fault_put_dec(partition_id);
+  fault_puts("\n");
+  fault_puts("PC: ");
+  fault_put_hex(frame[6]);
+  fault_puts(", LR: ");
+  fault_put_hex(frame[5]);
+  fault_puts("\n");
+#endif
+
+  /* Halt system immediately - safer than partition recovery from fault context
+   */
+#ifdef POK_NEEDS_DEBUG
+  fault_puts("FATAL: Usage fault in partition ");
+  fault_put_dec(partition_id);
+  fault_puts(" - System halted for safety\n");
+#endif
+  __disable_irq(); /* Prevent livelock or nested faults */
+  while (1) {
+    __asm volatile("wfi");
+  }
+}
+
+/*
+ * Hard Fault Handler
+ * Last resort fault handler
+ */
+DEFINE_FAULT_HANDLER_WRAPPER(HardFault_Handler, HardFault_Handler_C)
+
+/*
+ * Hard Fault Handler - C implementation
+ */
+static void HardFault_Handler_C(uint32_t *frame) {
+  uint8_t partition_id;
+
+  if (frame == NULL) {
+    while (1) {
+      __asm volatile("wfi");
+    }
+  }
+
+  extern uint8_t pok_current_partition;
+  partition_id = pok_current_partition;
+
+#ifdef POK_NEEDS_DEBUG
+  fault_puts("HardFault in partition ");
+  fault_put_dec(partition_id);
+  fault_puts("\n");
+  fault_puts("PC: ");
+  fault_put_hex(frame[6]);
+  fault_puts(", LR: ");
+  fault_put_hex(frame[5]);
+  fault_puts(", PSR: ");
+  fault_put_hex(frame[7]);
+  fault_puts("\n");
+  fault_puts("r0: ");
+  fault_put_hex(frame[0]);
+  fault_puts(", r1: ");
+  fault_put_hex(frame[1]);
+  fault_puts(", r2: ");
+  fault_put_hex(frame[2]);
+  fault_puts(", r3: ");
+  fault_put_hex(frame[3]);
+  fault_puts("\n");
+#endif
+
+  /* Halt system immediately - HardFault indicates severe system error */
+#ifdef POK_NEEDS_DEBUG
+  fault_puts(
+      "FATAL: Hard fault recovery disabled - System halted for safety\n");
+#endif
+  __disable_irq(); /* Prevent livelock or nested faults */
+  while (1) {
+    __asm volatile("wfi");
+  }
+}

--- a/kernel/arch/arm/memory_config.h
+++ b/kernel/arch/arm/memory_config.h
@@ -1,0 +1,115 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_MEMORY_CONFIG_H__
+#define __POK_ARM_MEMORY_CONFIG_H__
+
+/**
+ * \file    arch/arm/memory_config.h
+ * \brief   Configurable memory layout definitions for ARM platforms
+ * \author  POK team
+ *
+ * This file provides configurable memory layout constants that can be
+ * overridden per BSP to support different ARM Cortex-M hardware configurations.
+ */
+
+/* Default memory configuration - can be overridden by BSP-specific headers */
+
+#ifndef POK_FLASH_BASE
+#define POK_FLASH_BASE 0x08000000UL /* Default STM32F4 flash base */
+#endif
+
+#ifndef POK_SRAM_BASE
+#define POK_SRAM_BASE 0x20000000UL /* Default STM32F4 SRAM base */
+#endif
+
+#ifndef POK_SRAM_SIZE
+#define POK_SRAM_SIZE 0x20000UL /* Default 128KB SRAM */
+#endif
+
+#ifndef POK_KERNEL_MEMORY_SIZE
+#define POK_KERNEL_MEMORY_SIZE 0x8000UL /* Default 32KB for kernel */
+#endif
+
+/* Derived memory layout */
+#define POK_KERNEL_MEMORY_BASE POK_SRAM_BASE
+#define POK_USER_MEMORY_BASE (POK_SRAM_BASE + POK_KERNEL_MEMORY_SIZE)
+#define POK_USER_MEMORY_SIZE (POK_SRAM_SIZE - POK_KERNEL_MEMORY_SIZE)
+
+/* Memory alignment constants - defined before guards that reference them */
+#define POK_MEMORY_ALIGNMENT 8
+#define POK_MEMORY_ALIGNMENT_MASK (POK_MEMORY_ALIGNMENT - 1)
+
+/* ARM Cortex-M MPU subregion alignment - 256 bytes preferred for optimal region
+ * usage */
+#define MPU_SUBREGION_ALIGNMENT 256
+#define MPU_SUBREGION_ALIGNMENT_MASK (MPU_SUBREGION_ALIGNMENT - 1)
+
+/* Compile-time power-of-two checks for alignment assumptions */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#define POK_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#else
+#define POK_STATIC_ASSERT(cond, msg)                                           \
+  typedef char static_assertion_##__LINE__[(cond) ? 1 : -1]
+#endif
+
+POK_STATIC_ASSERT((POK_MEMORY_ALIGNMENT & (POK_MEMORY_ALIGNMENT - 1)) == 0,
+                  "POK_MEMORY_ALIGNMENT must be power of 2");
+POK_STATIC_ASSERT((MPU_SUBREGION_ALIGNMENT & (MPU_SUBREGION_ALIGNMENT - 1)) ==
+                      0,
+                  "MPU_SUBREGION_ALIGNMENT must be power of 2");
+
+/* Compile-time guards for memory layout assumptions */
+#if POK_KERNEL_MEMORY_SIZE >= POK_SRAM_SIZE
+#error "POK_KERNEL_MEMORY_SIZE must be smaller than POK_SRAM_SIZE"
+#endif
+
+#if POK_KERNEL_MEMORY_SIZE == 0
+#error "POK_KERNEL_MEMORY_SIZE cannot be zero"
+#endif
+
+#if POK_SRAM_SIZE == 0
+#error "POK_SRAM_SIZE cannot be zero"
+#endif
+
+#if (POK_SRAM_BASE & (POK_MEMORY_ALIGNMENT - 1)) != 0
+#error "POK_SRAM_BASE must be aligned to POK_MEMORY_ALIGNMENT"
+#endif
+
+#if (POK_KERNEL_MEMORY_SIZE & (POK_MEMORY_ALIGNMENT - 1)) != 0
+#error "POK_KERNEL_MEMORY_SIZE must be aligned to POK_MEMORY_ALIGNMENT"
+#endif
+
+/* Ensure minimum viable memory sizes */
+#if POK_KERNEL_MEMORY_SIZE < 0x2000UL
+#error "POK_KERNEL_MEMORY_SIZE must be at least 8KB for basic kernel operation"
+#endif
+
+#if POK_USER_MEMORY_SIZE < 0x1000UL
+#error "Insufficient user memory - need at least 4KB for partitions"
+#endif
+
+/* MPU subregion alignment warning - kernel size should align for efficient
+ * Cortex-M MPU usage */
+#if (POK_KERNEL_MEMORY_SIZE & MPU_SUBREGION_ALIGNMENT_MASK) != 0
+#warning                                                                       \
+    "POK_KERNEL_MEMORY_SIZE not aligned to MPU subregion boundary (256 bytes) - may reduce Cortex-M MPU efficiency"
+#endif
+
+/* Kernel region size for MPU configuration */
+#ifndef POK_KERNEL_REGION_SIZE
+#define POK_KERNEL_REGION_SIZE POK_KERNEL_MEMORY_SIZE
+#endif
+
+#endif /* !__POK_ARM_MEMORY_CONFIG_H__ */

--- a/kernel/arch/arm/mpu.c
+++ b/kernel/arch/arm/mpu.c
@@ -1,0 +1,374 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/mpu.c
+ * \author  POK team
+ * \brief   ARM Cortex-M MPU (Memory Protection Unit) implementation
+ */
+
+/* POK system headers */
+#include <errno.h>
+#include <libc.h>
+
+/* POK core headers */
+#include <core/partition.h>
+
+/* Architecture-specific headers */
+#include "arch.h"
+#include "mpu.h"
+#include "mpu_utils.h"
+
+static uint8_t mpu_region_count = 0;
+static mpu_region_t mpu_regions[MPU_MAX_REGIONS];
+
+/**
+ * Initialize the Memory Protection Unit (MPU)
+ * Detects available MPU regions and sets up initial configuration
+ *
+ * @return POK_ERRNO_OK on success, POK_ERRNO_UNAVAILABLE if no MPU present
+ */
+pok_ret_t pok_mpu_init(void) {
+  uint32_t mpu_type;
+
+  /* Read MPU Type register to get number of regions */
+  mpu_type = MPU_TYPE;
+  mpu_region_count = (mpu_type >> 8) & ARM_REGISTER_BYTE_MASK;
+
+  if (mpu_region_count == 0) {
+    /* No MPU present */
+    return POK_ERRNO_UNAVAILABLE;
+  }
+
+  if (mpu_region_count > MPU_MAX_REGIONS) {
+#ifdef POK_NEEDS_DEBUG
+    printf("WARNING: Hardware has %d MPU regions, but POK configured for max "
+           "%d. Truncating to %d regions.\n",
+           mpu_region_count, MPU_MAX_REGIONS, MPU_MAX_REGIONS);
+#endif
+    mpu_region_count = MPU_MAX_REGIONS;
+  }
+
+  /* Disable MPU during configuration */
+  pok_mpu_disable();
+
+  /* Clear all regions */
+  memset(mpu_regions, 0, sizeof(mpu_regions));
+
+  for (uint8_t i = 0; i < mpu_region_count; i++) {
+    pok_mpu_disable_region(i);
+  }
+
+  /* Enable MPU with default memory map for privileged access */
+  pok_mpu_enable();
+
+  return POK_ERRNO_OK;
+}
+
+/**
+ * Configure an MPU region with specified protection attributes
+ *
+ * @param region MPU region number (0-7 typically)
+ * @param base_addr Base address of the region (must be aligned to size)
+ * @param size Size of the region (must be power of 2, minimum 32 bytes)
+ * @param attributes Access permissions and memory attributes
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
+pok_ret_t pok_mpu_configure_region(uint8_t region, uint32_t base_addr,
+                                   uint32_t size, uint32_t attributes) {
+  uint32_t rasr;
+
+  if (region >= mpu_region_count) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Validate size */
+  if (size < MPU_MIN_REGION_SIZE || !mpu_is_power_of_2(size)) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: MPU region size %u is not power-of-2 or below minimum\n",
+           size);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Ensure base address is aligned to size */
+  if (!mpu_is_aligned(base_addr, size)) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Configure attributes and size before disabling interrupts */
+  uint32_t size_field = pok_mpu_size_to_rasr(size);
+  if (size_field == 0) {
+    return POK_ERRNO_EINVAL;
+  }
+  rasr = size_field | attributes | MPU_RASR_ENABLE;
+
+  /* Make MPU region programming atomic w.r.t. interrupts */
+  uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+
+  /* Select region */
+  MPU_RNR = region;
+
+  /* Configure base address - ensure base address is properly masked and region
+   * is in correct position */
+  MPU_RBAR = (base_addr & MPU_RBAR_ADDR_MASK) | MPU_RBAR_VALID |
+             (region & MPU_RBAR_REGION_MASK);
+
+  /* Configure attributes and size */
+  MPU_RASR = rasr;
+
+  /* Data Synchronization Barrier */
+  __asm volatile("dsb" : : : "memory");
+
+  /* Instruction Synchronization Barrier - ARM recommends ISB after MPU updates
+   */
+  __asm volatile("isb" : : : "memory");
+
+  /* Restore interrupt state */
+  __set_PRIMASK(primask);
+
+  /* Store configuration */
+  mpu_regions[region].base_addr = base_addr;
+  mpu_regions[region].size = size;
+  mpu_regions[region].attributes = attributes;
+  mpu_regions[region].region_id = region;
+  mpu_regions[region].enabled = 1;
+
+  return POK_ERRNO_OK;
+}
+
+/**
+ * Configure an MPU region with subregion support to mask unused memory
+ *
+ * @param region MPU region number
+ * @param base_addr Base address of the region (must be aligned to size)
+ * @param actual_size Actual size needed (not power of 2)
+ * @param aligned_size Aligned size (power of 2)
+ * @param attributes Access permissions and memory attributes
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
+pok_ret_t pok_mpu_configure_region_with_subregions(uint8_t region,
+                                                   uint32_t base_addr,
+                                                   uint32_t actual_size,
+                                                   uint32_t aligned_size,
+                                                   uint32_t attributes) {
+  uint32_t rasr;
+  uint8_t subregion_disable = 0;
+
+  if (region >= mpu_region_count) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Validate aligned_size is a valid MPU size */
+  if (!MPU_IS_VALID_SIZE(aligned_size)) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: MPU aligned_size %u is not power-of-2 or below minimum\n",
+           aligned_size);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Validate actual_size bounds */
+  if (actual_size == 0 || actual_size > aligned_size) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: MPU actual_size %u must be > 0 and <= aligned_size %u\n",
+           actual_size, aligned_size);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Ensure base address is aligned to size using consistent helper macro */
+  if (!mpu_is_aligned(base_addr, aligned_size)) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Calculate subregion disable bits to mask unused memory */
+  if (aligned_size >=
+      ARM_MPU_MIN_SUBREGION_SIZE) { /* Minimum size for subregions */
+    uint32_t subregion_size =
+        aligned_size / ARM_MPU_SUBREGION_COUNT; /* MPU subregions */
+    uint32_t used_subregions =
+        (actual_size + subregion_size - 1) / subregion_size;
+
+    /* Disable unused subregions (set corresponding bits) */
+    for (uint8_t i = used_subregions; i < ARM_MPU_SUBREGION_COUNT; i++) {
+      subregion_disable |= (1 << i);
+    }
+
+#ifdef POK_NEEDS_DEBUG
+    if (subregion_disable != 0) {
+      uint32_t exposed_memory =
+          aligned_size - (used_subregions * subregion_size);
+      printf("MPU region %d: using subregions to hide %u bytes (mask=0x%02x)\n",
+             region, exposed_memory, subregion_disable);
+    }
+#endif
+  }
+
+  /* Validate size before disabling interrupts */
+  uint32_t size_field = pok_mpu_size_to_rasr(aligned_size);
+  if (size_field == 0) {
+    return POK_ERRNO_EINVAL;
+  }
+  rasr = size_field | attributes | (subregion_disable << MPU_RASR_SRD_SHIFT) |
+         MPU_RASR_ENABLE;
+
+  /* Make MPU region programming atomic w.r.t. interrupts */
+  uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+
+  /* Select region */
+  MPU_RNR = region;
+
+  /* Configure base address - ensure base address is properly masked and region
+   * is in correct position */
+  MPU_RBAR = (base_addr & MPU_RBAR_ADDR_MASK) | MPU_RBAR_VALID |
+             (region & MPU_RBAR_REGION_MASK);
+
+  /* Configure attributes, size, and subregion disable */
+  MPU_RASR = rasr;
+
+  /* Data Synchronization Barrier */
+  __asm volatile("dsb" : : : "memory");
+
+  /* Instruction Synchronization Barrier - ARM recommends ISB after MPU updates
+   */
+  __asm volatile("isb" : : : "memory");
+
+  /* Restore interrupt state */
+  __set_PRIMASK(primask);
+
+  /* Store configuration */
+  mpu_regions[region].base_addr = base_addr;
+  mpu_regions[region].size = aligned_size;
+  mpu_regions[region].attributes = attributes;
+  mpu_regions[region].region_id = region;
+  mpu_regions[region].enabled = 1;
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_mpu_enable_region(uint8_t region) {
+  if (region >= mpu_region_count) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  if (!mpu_regions[region].enabled) {
+    uint32_t primask = __get_PRIMASK();
+    __disable_irq();
+
+    MPU_RNR = region;
+    MPU_RASR |= MPU_RASR_ENABLE;
+    mpu_regions[region].enabled = 1;
+
+    __asm volatile("dsb" : : : "memory");
+    __asm volatile("isb" : : : "memory");
+
+    __set_PRIMASK(primask);
+  }
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_mpu_disable_region(uint8_t region) {
+  if (region >= mpu_region_count) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+
+  MPU_RNR = region;
+  MPU_RASR &= ~MPU_RASR_ENABLE;
+  mpu_regions[region].enabled = 0;
+
+  __asm volatile("dsb" : : : "memory");
+  __asm volatile("isb" : : : "memory");
+
+  __set_PRIMASK(primask);
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_mpu_enable(void) {
+  /* Enable MPU with background region for privileged access */
+  MPU_CTRL = MPU_CTRL_ENABLE | MPU_CTRL_PRIVDEFENA;
+
+  /* Data Synchronization Barrier */
+  __asm volatile("dsb" : : : "memory");
+  /* Instruction Synchronization Barrier */
+  __asm volatile("isb" : : : "memory");
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_mpu_disable(void) {
+  /* Disable MPU */
+  MPU_CTRL = 0;
+
+  __asm volatile("dsb" : : : "memory");
+  __asm volatile("isb" : : : "memory");
+
+  return POK_ERRNO_OK;
+}
+
+uint8_t pok_mpu_get_region_count(void) { return mpu_region_count; }
+
+uint32_t pok_mpu_size_to_rasr(uint32_t size) {
+  uint32_t rasr_size = 0;
+
+  /* Size must be power of 2 and >= minimum size */
+  if (size < MPU_MIN_REGION_SIZE || !mpu_is_power_of_2(size)) {
+    return 0; /* Invalid size */
+  }
+
+  /* Calculate size field (log2(size) - 1) optimized using GCC builtin */
+  /* For ARM Cortex-M, GCC will generate CLZ instruction when available */
+  rasr_size = (31 - __builtin_clz(size)) - 1;
+
+  return (rasr_size << MPU_RASR_SIZE_SHIFT) & MPU_RASR_SIZE_MASK;
+}
+
+uint8_t pok_mpu_get_active_user_region(void) {
+  /* Iterate through user regions (1 to POK_CONFIG_NB_PARTITIONS) to find active
+   * one */
+  for (uint8_t region = 1; region <= POK_CONFIG_NB_PARTITIONS; region++) {
+    if (region >= mpu_region_count) {
+      break;
+    }
+
+    /* Select region to read its configuration */
+    MPU_RNR = region;
+
+    /* Check if region is enabled */
+    if (MPU_RASR & MPU_RASR_ENABLE) {
+      return region;
+    }
+  }
+
+  return 0; /* No active user region found, return kernel region */
+}
+
+uint32_t pok_mpu_get_region_base(uint8_t region) {
+  if (region >= mpu_region_count) {
+    return 0;
+  }
+
+  /* Select region to read its configuration */
+  MPU_RNR = region;
+
+  /* Return base address (mask out region number and valid bit) */
+  return (MPU_RBAR & ~(MPU_RBAR_REGION_MASK | MPU_RBAR_VALID));
+}

--- a/kernel/arch/arm/mpu.h
+++ b/kernel/arch/arm/mpu.h
@@ -1,0 +1,160 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_MPU_H__
+#define __POK_ARM_MPU_H__
+
+#include "cortex_m_config.h"
+#include <errno.h>
+#include <types.h>
+
+/* ARM Cortex-M MPU Register Base */
+#define MPU_BASE 0xE000ED90
+
+/* MPU Registers */
+#define MPU_TYPE (*((volatile uint32_t *)(MPU_BASE + 0x00)))
+#define MPU_CTRL (*((volatile uint32_t *)(MPU_BASE + 0x04)))
+#define MPU_RNR (*((volatile uint32_t *)(MPU_BASE + 0x08)))
+#define MPU_RBAR (*((volatile uint32_t *)(MPU_BASE + 0x0C)))
+#define MPU_RASR (*((volatile uint32_t *)(MPU_BASE + 0x10)))
+
+/* MPU Control Register bits */
+#define MPU_CTRL_ENABLE (1 << 0)
+#define MPU_CTRL_HFNMIENA (1 << 1)
+#define MPU_CTRL_PRIVDEFENA (1 << 2)
+
+/* MPU Region Base Address Register bits */
+#define MPU_RBAR_VALID (1 << 4)
+#define MPU_RBAR_REGION_MASK 0x0F
+#define MPU_RBAR_ADDR_MASK                                                     \
+  0xFFFFFFE0 /* Mask for base address (clears region + valid bits) */
+
+/* MPU Region Attribute and Size Register bits */
+#define MPU_RASR_ENABLE (1 << 0)
+#define MPU_RASR_SIZE_SHIFT 1
+#define MPU_RASR_SIZE_MASK (0x1F << MPU_RASR_SIZE_SHIFT)
+#define MPU_RASR_SRD_SHIFT 8
+#define MPU_RASR_SRD_MASK (0xFF << MPU_RASR_SRD_SHIFT)
+#define MPU_RASR_B (1 << 16)
+#define MPU_RASR_C (1 << 17)
+#define MPU_RASR_S (1 << 18)
+#define MPU_RASR_TEX_SHIFT 19
+#define MPU_RASR_TEX_MASK (0x7 << MPU_RASR_TEX_SHIFT)
+#define MPU_RASR_AP_SHIFT 24
+#define MPU_RASR_AP_MASK (0x7 << MPU_RASR_AP_SHIFT)
+#define MPU_RASR_XN (1 << 28)
+
+/* Access Permission encoding (pre-shifted for RASR register) */
+#define MPU_AP_NO_ACCESS (0x0 << MPU_RASR_AP_SHIFT)
+#define MPU_AP_PRIV_RW (0x1 << MPU_RASR_AP_SHIFT)
+#define MPU_AP_PRIV_RW_USER_RO (0x2 << MPU_RASR_AP_SHIFT)
+#define MPU_AP_ALL_RW (0x3 << MPU_RASR_AP_SHIFT)
+#define MPU_AP_PRIV_RO (0x5 << MPU_RASR_AP_SHIFT)
+#define MPU_AP_ALL_RO (0x6 << MPU_RASR_AP_SHIFT)
+
+/* Memory attributes (TEX, C, B combinations) */
+#define MPU_ATTR_NORMAL (MPU_RASR_C | MPU_RASR_B)
+#define MPU_ATTR_DEVICE 0
+#define MPU_ATTR_STRONGLY_ORDERED 0
+
+/* TEX/C/B Helper Macros for Common Memory Types */
+#define MPU_TEX(x) ((x) << MPU_RASR_TEX_SHIFT)
+
+/* Common Memory Type Combinations (TEX[2:0], C, B) */
+#define MPU_ATTR_FLASH_ROM                                                     \
+  (MPU_TEX(0) | MPU_RASR_C) /* TEX=000, C=1, B=0 - Normal, Non-cacheable */
+#define MPU_ATTR_INTERNAL_SRAM                                                 \
+  (MPU_TEX(0) | MPU_RASR_C |                                                   \
+   MPU_RASR_B) /* TEX=000, C=1, B=1 - Normal, Write-back cacheable */
+#define MPU_ATTR_EXTERNAL_RAM                                                  \
+  (MPU_TEX(1) | MPU_RASR_C |                                                   \
+   MPU_RASR_B) /* TEX=001, C=1, B=1 - Normal, Write-back cacheable */
+
+/* Peripheral Memory Attributes - Platform-specific optimizations */
+#define MPU_ATTR_PERIPHERAL_STRONGLY_ORDERED                                   \
+  (MPU_TEX(0)) /* TEX=000, C=0, B=0 - Strongly-ordered for critical regs */
+#define MPU_ATTR_PERIPHERAL_DEVICE                                             \
+  (MPU_TEX(2)) /* TEX=010, C=0, B=0 - Device memory for normal peripherals */
+#define MPU_ATTR_PERIPHERAL_DEVICE_XN                                          \
+  (MPU_TEX(2) | MPU_RASR_XN) /* Device memory + Execute Never */
+
+/* Legacy compatibility - use device memory for better performance */
+#define MPU_ATTR_PERIPHERAL MPU_ATTR_PERIPHERAL_DEVICE
+#define MPU_ATTR_PERIPHERAL_XN MPU_ATTR_PERIPHERAL_DEVICE_XN
+
+/* Access Permission Helper Macros */
+#define MPU_PERM_NO_ACCESS() MPU_AP_NO_ACCESS
+#define MPU_PERM_PRIV_RW() MPU_AP_PRIV_RW
+#define MPU_PERM_USER_RO() MPU_AP_PRIV_RW_USER_RO
+#define MPU_PERM_ALL_RW() MPU_AP_ALL_RW
+#define MPU_PERM_PRIV_RO() MPU_AP_PRIV_RO
+#define MPU_PERM_ALL_RO() MPU_AP_ALL_RO
+
+/* Combined Configuration Macros for Common Use Cases */
+#define MPU_CONFIG_FLASH_CODE (MPU_ATTR_FLASH_ROM | MPU_PERM_ALL_RO())
+#define MPU_CONFIG_SRAM_DATA                                                   \
+  (MPU_ATTR_INTERNAL_SRAM | MPU_PERM_ALL_RW() | MPU_RASR_XN)
+#define MPU_CONFIG_PERIPHERAL_RW (MPU_ATTR_PERIPHERAL_XN | MPU_PERM_PRIV_RW())
+#define MPU_CONFIG_USER_STACK                                                  \
+  (MPU_ATTR_INTERNAL_SRAM | MPU_PERM_ALL_RW() | MPU_RASR_XN)
+#define MPU_CONFIG_KERNEL_DATA                                                 \
+  (MPU_ATTR_INTERNAL_SRAM | MPU_PERM_PRIV_RW() | MPU_RASR_XN)
+
+/* STM32F4-specific peripheral configurations for different memory access
+ * patterns */
+#define MPU_CONFIG_PERIPHERAL_CRITICAL                                         \
+  (MPU_ATTR_PERIPHERAL_STRONGLY_ORDERED | MPU_PERM_PRIV_RW() | MPU_RASR_XN)
+#define MPU_CONFIG_PERIPHERAL_DEVICE                                           \
+  (MPU_ATTR_PERIPHERAL_DEVICE_XN | MPU_PERM_PRIV_RW())
+#define MPU_CONFIG_CCM_SRAM                                                    \
+  (MPU_ATTR_INTERNAL_SRAM | MPU_PERM_PRIV_RW() | MPU_RASR_XN)
+
+/* MPU Size and Validation Helper Macros */
+#define MPU_MIN_REGION_SIZE 32 /* Minimum MPU region size */
+#define MPU_IS_POWER_OF_2(x) (((x) != 0) && (((x) & ((x) - 1)) == 0))
+#define MPU_IS_VALID_SIZE(x)                                                   \
+  ((x) >= MPU_MIN_REGION_SIZE && MPU_IS_POWER_OF_2(x))
+#define MPU_IS_ALIGNED(addr, size) (((addr) & ((size) - 1)) == 0)
+
+/* Maximum number of MPU regions */
+#define MPU_MAX_REGIONS CORTEX_M_MPU_MAX_REGIONS
+
+/* MPU region configuration structure */
+typedef struct {
+  uint32_t base_addr;
+  uint32_t size;
+  uint32_t attributes;
+  uint8_t region_id;
+  uint8_t enabled;
+} mpu_region_t;
+
+/* Function prototypes */
+pok_ret_t pok_mpu_init(void);
+pok_ret_t pok_mpu_configure_region(uint8_t region, uint32_t base_addr,
+                                   uint32_t size, uint32_t attributes);
+pok_ret_t pok_mpu_configure_region_with_subregions(uint8_t region,
+                                                   uint32_t base_addr,
+                                                   uint32_t actual_size,
+                                                   uint32_t aligned_size,
+                                                   uint32_t attributes);
+pok_ret_t pok_mpu_enable_region(uint8_t region);
+pok_ret_t pok_mpu_disable_region(uint8_t region);
+pok_ret_t pok_mpu_enable(void);
+pok_ret_t pok_mpu_disable(void);
+uint8_t pok_mpu_get_region_count(void);
+uint32_t pok_mpu_size_to_rasr(uint32_t size);
+uint8_t pok_mpu_get_active_user_region(void);
+uint32_t pok_mpu_get_region_base(uint8_t region);
+
+#endif /* !__POK_ARM_MPU_H__ */

--- a/kernel/arch/arm/mpu_utils.h
+++ b/kernel/arch/arm/mpu_utils.h
@@ -1,0 +1,70 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_MPU_UTILS_H__
+#define __POK_ARM_MPU_UTILS_H__
+
+#include "cortex_m_config.h"
+#include <stdint.h>
+#include <types.h>
+
+/**
+ * \file    arch/arm/mpu_utils.h
+ * \brief   Shared MPU alignment and utility functions
+ * \author  POK team
+ */
+
+#define MPU_MIN_REGION_SIZE CORTEX_M_MPU_MIN_REGION_SIZE
+
+/**
+ * Round up size to next power of 2, with minimum of MPU_MIN_REGION_SIZE
+ *
+ * @param size Size to round up
+ * @return Next power of 2 >= size, minimum MPU_MIN_REGION_SIZE
+ */
+static inline uint32_t mpu_align_size_to_power_of_2(uint32_t size) {
+  if (size <= MPU_MIN_REGION_SIZE) {
+    return MPU_MIN_REGION_SIZE;
+  }
+
+  /* Find next power of 2 using bit manipulation */
+  uint32_t aligned_size = 1;
+  while (aligned_size < size) {
+    aligned_size <<= 1;
+  }
+  return aligned_size;
+}
+
+/**
+ * Check if a value is power of 2
+ *
+ * @param value Value to check
+ * @return true if power of 2, false otherwise
+ */
+static inline pok_bool_t mpu_is_power_of_2(uint32_t value) {
+  return (value != 0) && ((value & (value - 1)) == 0);
+}
+
+/**
+ * Check if address is aligned to size
+ *
+ * @param addr Address to check
+ * @param size Alignment size (must be power of 2)
+ * @return TRUE if aligned, FALSE otherwise
+ */
+static inline pok_bool_t mpu_is_aligned(uint32_t addr, uint32_t size) {
+  return (addr & (size - 1)) == 0;
+}
+
+#endif /* !__POK_ARM_MPU_UTILS_H__ */

--- a/kernel/arch/arm/nvic.c
+++ b/kernel/arch/arm/nvic.c
@@ -1,0 +1,367 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/nvic.c
+ * \author  POK team
+ * \brief   ARM Cortex-M NVIC (Nested Vectored Interrupt Controller)
+ * implementation
+ */
+
+/* POK system headers */
+#include <errno.h>
+#include <libc.h>
+
+/* Architecture-specific headers */
+#include "arch.h"
+#include "cortex_m_config.h"
+#include "nvic.h"
+#include "stm32f4/peripherals.h"
+
+/* External vector table (defined in startup code) */
+/* Note: We get the ROM vector table location from VTOR instead of assuming
+ * a fixed location, making this more robust across different memory layouts */
+
+/* RAM-based vector table for runtime handler updates */
+#define NVIC_VECTOR_COUNT CORTEX_M_NVIC_VECTOR_COUNT
+#define NVIC_VECTOR_TABLE_SIZE CORTEX_M_NVIC_VECTOR_TABLE_SIZE
+#define NVIC_VECTOR_TABLE_ALIGNMENT CORTEX_M_NVIC_VECTOR_TABLE_ALIGNMENT
+static vector_table_entry_t ram_vector_table[NVIC_VECTOR_COUNT]
+    __attribute__((aligned(NVIC_VECTOR_TABLE_ALIGNMENT)));
+static uint8_t vector_table_relocated = 0;
+
+/* Default handlers */
+static void pok_nvic_default_handler(void) {
+  /* Default handler - log error and halt system safely
+   * Avoid WFI as it may create unrecoverable state if no other interrupts occur
+   */
+#ifdef POK_NEEDS_DEBUG
+  printf("FATAL: Unhandled interrupt/exception occurred\n");
+#endif
+
+  /* Disable interrupts and halt */
+  __disable_irq();
+  while (1) {
+    /* Busy wait instead of WFI to ensure system remains debuggable */
+    __asm volatile("nop");
+  }
+}
+
+/**
+ * Relocate vector table from FLASH to RAM for runtime handler updates
+ */
+static pok_ret_t pok_nvic_relocate_vector_table(void) {
+  if (vector_table_relocated) {
+    return POK_ERRNO_OK; /* Already relocated */
+  }
+
+  /* Get current ROM vector table location from VTOR register
+   * This makes the code more robust across different memory layouts */
+  uint32_t rom_table_addr = SCB_VTOR;
+
+  /* Validate ROM table address is in Flash region and entire table fits */
+  if (rom_table_addr < STM32F4_FLASH_BASE ||
+      rom_table_addr >= (STM32F4_FLASH_BASE + STM32F4_FLASH_SIZE)) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: ROM vector table at invalid address: 0x%x (outside Flash "
+           "region 0x%x-0x%x)\n",
+           rom_table_addr, STM32F4_FLASH_BASE,
+           STM32F4_FLASH_BASE + STM32F4_FLASH_SIZE - 1);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Ensure full vector table fits in Flash using overflow-safe math */
+  uint32_t flash_end = STM32F4_FLASH_BASE + STM32F4_FLASH_SIZE;
+  uint32_t table_end = rom_table_addr + NVIC_VECTOR_TABLE_SIZE;
+
+  /* Check for overflow in table_end calculation */
+  if (table_end < rom_table_addr || table_end > flash_end) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: ROM vector table (0x%x + %u bytes) extends beyond Flash "
+           "region (end: 0x%x)\n",
+           rom_table_addr, NVIC_VECTOR_TABLE_SIZE, flash_end);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Validate vector table alignment */
+  if ((rom_table_addr & (NVIC_VECTOR_TABLE_ALIGNMENT - 1)) != 0) {
+#ifdef POK_NEEDS_DEBUG
+    printf(
+        "ERROR: ROM vector table misaligned: 0x%x (must be %d-byte aligned)\n",
+        rom_table_addr, NVIC_VECTOR_TABLE_ALIGNMENT);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  vector_table_entry_t *rom_vector_table =
+      (vector_table_entry_t *)rom_table_addr;
+
+  /* Copy ROM vector table to RAM */
+  for (int i = 0; i < NVIC_VECTOR_COUNT; i++) {
+    ram_vector_table[i] = rom_vector_table[i];
+  }
+
+  /* Update VTOR register to point to RAM vector table */
+  uint32_t ram_table_addr = (uint32_t)ram_vector_table;
+
+  /* Validate alignment (must be next power of 2 of table size) */
+  if (ram_table_addr & (NVIC_VECTOR_TABLE_ALIGNMENT - 1)) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: RAM vector table not properly aligned: 0x%x (required: %d "
+           "bytes)\n",
+           ram_table_addr, NVIC_VECTOR_TABLE_ALIGNMENT);
+#endif
+    return POK_ERRNO_EFAULT;
+  }
+
+  SCB_VTOR = ram_table_addr;
+  vector_table_relocated = 1;
+
+#ifdef POK_NEEDS_DEBUG
+  printf("Vector table relocated to RAM at 0x%x\n", ram_table_addr);
+#endif
+
+  __asm volatile("dsb" ::: "memory");
+  __asm volatile("isb");
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_nvic_init(void) {
+  pok_ret_t ret;
+
+  /* Relocate vector table to RAM for runtime handler updates */
+  ret = pok_nvic_relocate_vector_table();
+  if (ret != POK_ERRNO_OK) {
+    return (ret);
+  }
+
+  /* Enable division-by-zero trap to trigger UsageFault */
+  SCB_CCR |= SCB_CCR_DIV_0_TRP;
+
+  /* Enable memory management, bus fault, and usage fault exceptions */
+  SCB_SHCSR |=
+      SCB_SHCSR_MEMFAULTENA | SCB_SHCSR_BUSFAULTENA | SCB_SHCSR_USGFAULTENA;
+
+  /* Set fault handlers to high priority for proper error handling */
+  pok_nvic_set_priority(EXCEPTION_MEMMANAGE, NVIC_PRIORITY_HIGH);
+  pok_nvic_set_priority(EXCEPTION_BUSFAULT, NVIC_PRIORITY_HIGH);
+  pok_nvic_set_priority(EXCEPTION_USAGEFAULT, NVIC_PRIORITY_HIGH);
+
+  /* Set PendSV and SysTick to lowest priority for context switching */
+  pok_nvic_set_priority(EXCEPTION_PENDSV, NVIC_PRIORITY_LOWEST);
+  pok_nvic_set_priority(EXCEPTION_SYSTICK, NVIC_PRIORITY_LOWEST);
+
+  /* Clear all pending interrupts based on actual IRQ count
+   * Each ICPR register handles 32 IRQs, so calculate number of registers needed
+   * STM32F4 has 82 external IRQs, requiring 3 ICPR registers (0-2) */
+  const int external_irqs =
+      CORTEX_M_NVIC_VECTOR_COUNT - 16; /* Subtract 16 system vectors */
+  const int icpr_regs_needed =
+      (external_irqs + 31) / 32; /* Round up to next register */
+
+  for (int i = 0; i < icpr_regs_needed; i++) {
+    NVIC_ICPR[i] = 0xFFFFFFFFU;
+  }
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_nvic_set_handler(uint8_t irq, void (*handler)(void)) {
+  if (irq >= NVIC_VECTOR_COUNT) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Prevent overwriting critical system vectors */
+  if (irq == 0 || irq == 1) {
+    /* Vector 0: Initial Stack Pointer (MSP), Vector 1: Reset Handler */
+    return POK_ERRNO_EINVAL; /* Cannot modify critical system vectors */
+  }
+
+  /* Ensure vector table has been relocated to RAM */
+  if (!vector_table_relocated) {
+    pok_ret_t ret = pok_nvic_relocate_vector_table();
+    if (ret != POK_ERRNO_OK) {
+      return (ret);
+    }
+  }
+
+  /* Disable interrupts during handler update to prevent race conditions */
+  uint8_t irq_was_enabled = 0;
+  uint32_t primask_state = 0;
+
+  if (irq >= EXCEPTION_IRQ0) {
+    /* External IRQ - disable specific IRQ */
+    uint8_t external_irq = irq - EXCEPTION_IRQ0;
+    uint32_t reg_idx = external_irq / 32;
+    uint32_t bit_pos = external_irq % 32;
+    if (NVIC_ISER[reg_idx] & (1U << bit_pos)) {
+      irq_was_enabled = 1;
+      NVIC_ICER[reg_idx] = (1U << bit_pos); /* Disable IRQ */
+    }
+  } else if (irq >= 2 && irq <= 15) {
+    /* System exception - disable all interrupts to prevent race */
+    primask_state = __get_PRIMASK();
+    __disable_irq();
+  }
+
+  /* Set handler in RAM vector table */
+  if (handler == NULL) {
+    ram_vector_table[irq] = pok_nvic_default_handler;
+  } else {
+    ram_vector_table[irq] = handler;
+  }
+
+  /* Data Synchronization Barrier to ensure vector table update completes */
+  __asm volatile("dsb" : : : "memory");
+  __asm volatile("isb");
+
+  /* Re-enable interrupts */
+  if (irq >= EXCEPTION_IRQ0) {
+    /* External IRQ - re-enable specific IRQ if it was enabled */
+    if (irq_was_enabled) {
+      uint8_t external_irq = irq - EXCEPTION_IRQ0;
+      uint32_t reg_idx = external_irq / 32;
+      uint32_t bit_pos = external_irq % 32;
+      NVIC_ISER[reg_idx] = (1U << bit_pos);
+    }
+  } else if (irq >= 2 && irq <= 15) {
+    /* System exception - restore global interrupt state */
+    __set_PRIMASK(primask_state);
+  }
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_nvic_enable_irq(uint8_t irq) {
+  if (irq < EXCEPTION_IRQ0 || irq >= NVIC_VECTOR_COUNT) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  uint8_t external_irq = irq - EXCEPTION_IRQ0;
+  uint32_t reg_idx = external_irq / 32;
+  uint32_t bit_pos = external_irq % 32;
+
+  NVIC_ISER[reg_idx] = (1U << bit_pos);
+
+  /* Data Synchronization Barrier to ensure register write completes */
+  __asm volatile("dsb" : : : "memory");
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_nvic_disable_irq(uint8_t irq) {
+  if (irq < EXCEPTION_IRQ0 || irq >= NVIC_VECTOR_COUNT) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  uint8_t external_irq = irq - EXCEPTION_IRQ0;
+  uint32_t reg_idx = external_irq / 32;
+  uint32_t bit_pos = external_irq % 32;
+
+  NVIC_ICER[reg_idx] = (1U << bit_pos);
+
+  /* Data Synchronization Barrier to ensure register write completes */
+  __asm volatile("dsb" : : : "memory");
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority) {
+  if (irq >= NVIC_VECTOR_COUNT || priority > NVIC_PRIORITY_LOWEST) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  if (irq < EXCEPTION_IRQ0) {
+    /* System exception priority */
+    volatile uint32_t *shpr_reg;
+    uint8_t reg_offset;
+
+    if (irq >= 4 && irq <= 6) {
+      /* MemManage (4), BusFault (5), UsageFault (6) */
+      shpr_reg = (volatile uint32_t *)&SCB_SHPR1;
+      reg_offset = (irq - 4) * 8;
+    } else if (irq == 11) {
+      /* SVCall (11) only */
+      shpr_reg = (volatile uint32_t *)&SCB_SHPR2;
+      reg_offset = 24; /* SVCall is at bits [31:24] of SHPR2 */
+    } else if (irq == 12 || (irq >= 14 && irq <= 15)) {
+      /* DebugMon (12), PendSV (14), SysTick (15) */
+      shpr_reg = (volatile uint32_t *)&SCB_SHPR3;
+      if (irq == 12) {
+        reg_offset = 0; /* DebugMon is at bits [7:0] of SHPR3 */
+      } else if (irq == 14) {
+        reg_offset = 16; /* PendSV is at bits [23:16] of SHPR3 */
+      } else {           /* irq == 15 */
+        reg_offset = 24; /* SysTick is at bits [31:24] of SHPR3 */
+      }
+    } else {
+      return POK_ERRNO_EINVAL;
+    }
+
+    /* Validate offset is within 32-bit register and properly aligned for 8-bit
+     * priority field */
+    if (reg_offset > 24 || (reg_offset & 7) != 0) {
+#ifdef POK_NEEDS_DEBUG
+      printf("ERROR: Invalid priority register offset %d for IRQ %d\n",
+             reg_offset, irq);
+#endif
+      return POK_ERRNO_EINVAL;
+    }
+
+    uint32_t mask = ~(ARM_PRIORITY_MASK << reg_offset);
+    *shpr_reg = (*shpr_reg & mask) | ((priority << 4) << reg_offset);
+  } else {
+    /* External interrupt priority */
+    uint8_t external_irq = irq - EXCEPTION_IRQ0;
+    NVIC_IPR[external_irq] = priority << 4;
+  }
+
+  /* Data Synchronization Barrier to ensure priority register write completes */
+  __asm volatile("dsb" : : : "memory");
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_nvic_clear_pending(uint8_t irq) {
+  if (irq < EXCEPTION_IRQ0 || irq >= NVIC_VECTOR_COUNT) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  uint8_t external_irq = irq - EXCEPTION_IRQ0;
+  uint32_t reg_idx = external_irq / 32;
+  uint32_t bit_pos = external_irq % 32;
+
+  NVIC_ICPR[reg_idx] = (1U << bit_pos);
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_nvic_set_vector_table(uint32_t offset) {
+  /* Vector table must be aligned to next power of 2 of table size */
+  if (offset & (NVIC_VECTOR_TABLE_ALIGNMENT - 1)) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  SCB_VTOR = offset;
+  __asm volatile("dsb" : : : "memory");
+  __asm volatile("isb");
+  return POK_ERRNO_OK;
+}
+
+/* Default exception handlers */
+void NMI_Handler(void) { pok_nvic_default_handler(); }
+
+void DebugMon_Handler(void) { pok_nvic_default_handler(); }

--- a/kernel/arch/arm/nvic.h
+++ b/kernel/arch/arm/nvic.h
@@ -1,0 +1,127 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_NVIC_H__
+#define __POK_ARM_NVIC_H__
+
+#include "cortex_m_config.h"
+#include <errno.h>
+#include <types.h>
+
+/* System Control Block (SCB) Base Address */
+#define SCB_BASE 0xE000ED00
+
+/* NVIC Base Address */
+#define NVIC_BASE 0xE000E100
+
+/* System Control Block Registers */
+#define SCB_ICSR (*((volatile uint32_t *)(SCB_BASE + 0x04)))
+#define SCB_VTOR (*((volatile uint32_t *)(SCB_BASE + 0x08)))
+#define SCB_AIRCR (*((volatile uint32_t *)(SCB_BASE + 0x0C)))
+#define SCB_SCR (*((volatile uint32_t *)(SCB_BASE + 0x10)))
+#define SCB_CCR (*((volatile uint32_t *)(SCB_BASE + 0x14)))
+#define SCB_SHCSR (*((volatile uint32_t *)(SCB_BASE + 0x24)))
+#define SCB_SHPR1 (*((volatile uint32_t *)(SCB_BASE + 0x18)))
+#define SCB_SHPR2 (*((volatile uint32_t *)(SCB_BASE + 0x1C)))
+#define SCB_SHPR3 (*((volatile uint32_t *)(SCB_BASE + 0x20)))
+
+/* NVIC Registers */
+#define NVIC_ISER ((volatile uint32_t *)(NVIC_BASE + 0x000))
+#define NVIC_ICER ((volatile uint32_t *)(NVIC_BASE + 0x080))
+#define NVIC_ISPR ((volatile uint32_t *)(NVIC_BASE + 0x100))
+#define NVIC_ICPR ((volatile uint32_t *)(NVIC_BASE + 0x180))
+#define NVIC_IPR ((volatile uint8_t *)(NVIC_BASE + 0x300))
+
+/* Exception Numbers */
+#define EXCEPTION_RESET 1
+#define EXCEPTION_NMI 2
+#define EXCEPTION_HARDFAULT 3
+#define EXCEPTION_MEMMANAGE 4
+#define EXCEPTION_BUSFAULT 5
+#define EXCEPTION_USAGEFAULT 6
+#define EXCEPTION_SVCALL 11
+#define EXCEPTION_DEBUGMON 12
+#define EXCEPTION_PENDSV 14
+#define EXCEPTION_SYSTICK 15
+
+/* External interrupt start */
+#define EXCEPTION_IRQ0 16
+
+/* System Control Register bits */
+#define SCB_SCR_SLEEPONEXIT (1 << 1)
+#define SCB_SCR_SLEEPDEEP (1 << 2)
+#define SCB_SCR_SEVONPEND (1 << 4)
+
+/* Interrupt Control and State Register bits */
+#define SCB_ICSR_PENDSTCLR (1 << 25)
+#define SCB_ICSR_PENDSTSET (1 << 26)
+#define SCB_ICSR_PENDSVCLR (1 << 27)
+#define SCB_ICSR_PENDSVSET (1 << 28)
+
+/* Configuration and Control Register bits */
+#define SCB_CCR_DIV_0_TRP (1 << 4)
+
+/* System Handler Control and State Register bits */
+#define SCB_SHCSR_MEMFAULTENA (1 << 16)
+#define SCB_SHCSR_BUSFAULTENA (1 << 17)
+#define SCB_SHCSR_USGFAULTENA (1 << 18)
+
+/* Application Interrupt and Reset Control Register */
+#define SCB_AIRCR_VECTKEY 0x05FA0000
+#define SCB_AIRCR_SYSRESETREQ (1 << 2)
+
+/* Priority levels and masks */
+#define ARM_PRIORITY_MASK 0xFF /* Used in nvic.c SHPR updates */
+
+/* Priority levels */
+#define NVIC_PRIORITY_HIGHEST 0
+#define NVIC_PRIORITY_HIGH 1
+#define NVIC_PRIORITY_NORMAL 8
+#define NVIC_PRIORITY_LOW 14
+#define NVIC_PRIORITY_LOWEST 15
+
+/* NVIC vector table configuration aliases */
+#define NVIC_VECTOR_COUNT CORTEX_M_NVIC_VECTOR_COUNT
+#define NVIC_VECTOR_TABLE_ALIGNMENT CORTEX_M_NVIC_VECTOR_TABLE_ALIGNMENT
+
+/* Maximum external interrupt number */
+#define NVIC_MAX_IRQ 239
+
+/* Vector table entry */
+typedef void (*vector_table_entry_t)(void);
+
+/* Function prototypes */
+pok_ret_t pok_nvic_init(void);
+pok_ret_t pok_nvic_set_handler(uint8_t irq, void (*handler)(void));
+pok_ret_t pok_nvic_enable_irq(uint8_t irq);
+pok_ret_t pok_nvic_disable_irq(uint8_t irq);
+pok_ret_t pok_nvic_set_priority(uint8_t irq, uint8_t priority);
+pok_ret_t pok_nvic_clear_pending(uint8_t irq);
+pok_ret_t pok_nvic_set_vector_table(uint32_t offset);
+
+/* System exception handlers */
+void Reset_Handler(void);
+void NMI_Handler(void);
+void SVC_Handler(void);
+void DebugMon_Handler(void);
+void PendSV_Handler(void);
+void SysTick_Handler(void);
+
+/* Fault handlers implemented in exceptions.c */
+void HardFault_Handler(void);
+void MemManage_Handler(void);
+void BusFault_Handler(void);
+void UsageFault_Handler(void);
+
+#endif /* !__POK_ARM_NVIC_H__ */

--- a/kernel/arch/arm/space.c
+++ b/kernel/arch/arm/space.c
@@ -1,0 +1,495 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/space.c
+ * \brief   ARM Cortex-M address space management using MPU
+ * \author  POK team
+ */
+
+/* POK system headers */
+#include <errno.h>
+#include <libc.h>
+#include <types.h>
+
+/* POK core headers */
+#include <bsp.h>
+#include <core/sched.h>
+
+/* Architecture-specific headers */
+#include "arch.h"
+#include "cortex_m_config.h"
+#include "mpu.h"
+#include "mpu_utils.h"
+#include "thread.h"
+
+#define KERNEL_STACK_SIZE 4096
+#define MEMORY_WASTE_THRESHOLD_PERCENT 25
+#define MEMORY_WASTE_CRITICAL_PERCENT                                          \
+  50 /* Fail allocation if waste exceeds this */
+#define STACK_ALIGNMENT_BYTES                                                  \
+  CORTEX_M_STACK_ALIGNMENT /* ARM Cortex-M requires 8-byte stack alignment */
+#define STACK_ALIGNMENT_MASK CORTEX_M_STACK_ALIGNMENT_MASK
+
+/* Helper function to align address down while keeping it within bounds */
+static inline uint32_t align_down(uint32_t value, uint32_t alignment) {
+  return value & ~(alignment - 1);
+}
+
+/* Partition space information */
+struct pok_space {
+  uint32_t phys_base;
+  uint32_t size;
+  uint8_t mpu_region;
+  uint8_t mpu_code_region; /* Separate code region for W^X enforcement */
+  uint32_t code_base;      /* Base address of code region */
+  uint32_t code_size;      /* Size of code region */
+};
+
+struct pok_space spaces[POK_CONFIG_NB_PARTITIONS];
+
+/**
+ * Create a memory space for a partition using MPU protection
+ *
+ * @param partition_id ID of the partition (0 to POK_CONFIG_NB_PARTITIONS-1)
+ * @param addr Base address of the partition memory space
+ * @param size Size of the partition memory space
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
+pok_ret_t pok_create_space(uint8_t partition_id, uint32_t addr, uint32_t size) {
+  uint32_t mpu_attributes;
+  uint8_t region_id;
+
+  if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Validate nonzero/valid size early to prevent division by zero */
+  if (size == 0) {
+    return POK_ERRNO_EINVAL; /* Zero size is invalid */
+  }
+
+  /* Use partition_id + 1 as region ID (reserve region 0 for kernel) */
+  region_id = partition_id + 1;
+
+  if (region_id >= pok_mpu_get_region_count()) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Configure MPU attributes for partition space - enforce W^X principle:
+   * - Read/Write access for data region (no execute)
+   * - Read/Execute access for code region (no write)
+   * - Normal memory with caching
+   * Note: This creates a data region first, code region will be separate
+   */
+  /* Use helper macro for partition data region (read-write, no execute) */
+  mpu_attributes = MPU_CONFIG_SRAM_DATA;
+
+  /* Align size to power of 2 (MPU requirement) */
+  uint32_t aligned_size = mpu_align_size_to_power_of_2(size);
+
+  /* Validate base address alignment matches MPU requirements */
+  if (!mpu_is_aligned(addr, aligned_size)) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Partition %d base addr 0x%x not aligned to size 0x%x\n",
+           partition_id, addr, aligned_size);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Configure MPU region - try subregions first to minimize waste */
+  uint32_t actual_exposed_memory = aligned_size - size;
+  pok_bool_t used_subregions = FALSE;
+  uint32_t configured_region_id = region_id; /* Track for rollback */
+
+  if (aligned_size >= ARM_MPU_MIN_SUBREGION_SIZE &&
+      (aligned_size - size) >= (size / 4)) {
+    /* Use subregions if region is large enough and waste is significant */
+    if (pok_mpu_configure_region_with_subregions(
+            region_id, addr, size, aligned_size, mpu_attributes) ==
+        POK_ERRNO_OK) {
+      used_subregions = TRUE;
+      /* Calculate real exposed memory with subregions - subregions can still
+       * expose unused memory at boundaries */
+      uint32_t subregion_size = aligned_size / 8; /* MPU has 8 subregions */
+      uint32_t needed_subregions = (size + subregion_size - 1) / subregion_size;
+      actual_exposed_memory = (needed_subregions * subregion_size) - size;
+    }
+  }
+
+  if (!used_subregions) {
+    /* Use standard region configuration */
+    if (pok_mpu_configure_region(region_id, addr, aligned_size,
+                                 mpu_attributes) != POK_ERRNO_OK) {
+      return POK_ERRNO_EFAULT;
+    }
+    /* Standard region exposes full aligned_size - size */
+    actual_exposed_memory = aligned_size - size;
+  }
+
+  /* Check waste after subregion masking */
+  if (actual_exposed_memory > 0) {
+    uint32_t waste_percent = (actual_exposed_memory * 100) / size;
+    if (waste_percent > MEMORY_WASTE_CRITICAL_PERCENT) {
+#ifdef POK_NEEDS_DEBUG
+      printf("ERROR: Partition %d wastes %u%% memory (%u bytes) "
+             "- exceeds %u%% limit\n",
+             partition_id, waste_percent, actual_exposed_memory,
+             MEMORY_WASTE_CRITICAL_PERCENT);
+#endif
+      /* Rollback: disable the configured MPU region */
+      pok_mpu_disable_region(configured_region_id);
+      return POK_ERRNO_EINVAL;
+    }
+
+#ifdef POK_NEEDS_DEBUG
+    if (waste_percent > MEMORY_WASTE_THRESHOLD_PERCENT) {
+      printf("WARNING: Partition %d wastes %u%% memory (%u bytes) "
+             "- protected by MPU hardware\n",
+             partition_id, waste_percent, actual_exposed_memory);
+    }
+#endif
+  }
+
+  /* Store partition information */
+  spaces[partition_id].phys_base = addr;
+  spaces[partition_id].size = size;
+  spaces[partition_id].mpu_region = region_id;
+  spaces[partition_id].mpu_code_region = 0; /* No code region yet */
+  spaces[partition_id].code_base = 0;
+  spaces[partition_id].code_size = 0;
+
+  /* Initially disable the region */
+  pok_mpu_disable_region(region_id);
+
+#ifdef POK_NEEDS_DEBUG
+  printf("pok_create_space: %d: %x %x (region %d)\n", partition_id, addr, size,
+         region_id);
+#endif
+
+  return POK_ERRNO_OK;
+}
+
+/**
+ * Create a separate code region for a partition to enforce W^X security
+ *
+ * @param partition_id ID of the partition
+ * @param code_addr Base address of the code region within partition
+ * @param code_size Size of the code region
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
+pok_ret_t pok_create_code_region(uint8_t partition_id, uint32_t code_addr,
+                                 uint32_t code_size) {
+  uint32_t mpu_attributes;
+  uint8_t region_id;
+
+  if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Require existing partition before creating code region */
+  if (spaces[partition_id].size == 0) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Cannot create code region for non-existent partition %d\n",
+           partition_id);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Use partition_id + 1 + POK_CONFIG_NB_PARTITIONS as code region ID */
+  region_id = partition_id + 1 + POK_CONFIG_NB_PARTITIONS;
+
+  /* Region budget check: Ensure we don't exceed available MPU regions
+   * Budget allocation:
+   * - Region 0: Reserved for kernel
+   * - Regions 1 to POK_CONFIG_NB_PARTITIONS: Partition data regions
+   * - Regions (POK_CONFIG_NB_PARTITIONS+1) to (2*POK_CONFIG_NB_PARTITIONS):
+   * Partition code regions Total needed: 1 + (2 * POK_CONFIG_NB_PARTITIONS)
+   */
+  uint32_t total_regions_needed = 1 + (2 * POK_CONFIG_NB_PARTITIONS);
+  uint32_t available_regions = pok_mpu_get_region_count();
+
+  if (total_regions_needed > available_regions) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: MPU region budget exceeded. Need %u regions, have %u\n",
+           total_regions_needed, available_regions);
+    printf("Reduce POK_CONFIG_NB_PARTITIONS or use MPU with more regions\n");
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  if (region_id >= available_regions) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Code region ID %u exceeds available regions %u\n", region_id,
+           available_regions);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Enforce code region is inside the partition bounds with overflow-safe math
+   */
+  if (code_size == 0) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Code region size cannot be zero for partition %d\n",
+           partition_id);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  uint32_t partition_base = spaces[partition_id].phys_base;
+
+  if (code_addr < partition_base) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Code region start 0x%x before partition bounds [0x%x-0x%x) "
+           "for partition %d\n",
+           code_addr, partition_base,
+           partition_base + spaces[partition_id].size, partition_id);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Use offset math to avoid overflow in end address calculation */
+  uint32_t code_offset = code_addr - partition_base;
+  if (code_offset + code_size > spaces[partition_id].size) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Code region [0x%x+%u) extends beyond partition bounds "
+           "[0x%x-0x%x) "
+           "for partition %d\n",
+           code_addr, code_size, partition_base,
+           partition_base + spaces[partition_id].size, partition_id);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Configure MPU attributes for code region - enforce W^X:
+   * - Read/Execute only (no write permission)
+   * - Normal memory with caching
+   */
+  /* Use helper macro for code region (read-only, executable) */
+  mpu_attributes = MPU_CONFIG_FLASH_CODE;
+
+  /* Align size to power of 2 (MPU requirement) */
+  uint32_t aligned_size = mpu_align_size_to_power_of_2(code_size);
+
+  /* Validate base address alignment matches MPU requirements */
+  if (!mpu_is_aligned(code_addr, aligned_size)) {
+#ifdef POK_NEEDS_DEBUG
+    printf(
+        "ERROR: Partition %d code region addr 0x%x not aligned to size 0x%x\n",
+        partition_id, code_addr, aligned_size);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Configure MPU region for partition code */
+  if (pok_mpu_configure_region(region_id, code_addr, aligned_size,
+                               mpu_attributes) != POK_ERRNO_OK) {
+    return POK_ERRNO_EFAULT;
+  }
+
+  /* Store code region information for space switching */
+  spaces[partition_id].mpu_code_region = region_id;
+  spaces[partition_id].code_base = code_addr;
+  spaces[partition_id].code_size = code_size;
+
+  /* Initially disable the code region */
+  pok_mpu_disable_region(region_id);
+
+#ifdef POK_NEEDS_DEBUG
+  printf("pok_create_code_region: partition %d: code addr=0x%x size=0x%x "
+         "(region %d)\n",
+         partition_id, code_addr, code_size, region_id);
+#endif
+
+  return POK_ERRNO_OK;
+}
+
+pok_ret_t pok_space_switch(uint8_t old_partition_id, uint8_t new_partition_id) {
+  if (old_partition_id < POK_CONFIG_NB_PARTITIONS) {
+    /* Disable old partition's data MPU region if valid (avoid affecting kernel
+     * region) */
+    if (spaces[old_partition_id].mpu_region != 0) {
+      pok_mpu_disable_region(spaces[old_partition_id].mpu_region);
+    }
+
+    /* Disable old partition's code region if it exists */
+    if (spaces[old_partition_id].mpu_code_region != 0) {
+      pok_mpu_disable_region(spaces[old_partition_id].mpu_code_region);
+    }
+  }
+
+  if (new_partition_id < POK_CONFIG_NB_PARTITIONS) {
+    /* Enable new partition's data MPU region if valid (avoid affecting kernel
+     * region) */
+    if (spaces[new_partition_id].mpu_region != 0) {
+      pok_mpu_enable_region(spaces[new_partition_id].mpu_region);
+    }
+
+    /* Enable new partition's code region if it exists (enforces W^X) */
+    if (spaces[new_partition_id].mpu_code_region != 0) {
+      pok_mpu_enable_region(spaces[new_partition_id].mpu_code_region);
+    }
+  }
+
+  return POK_ERRNO_OK;
+}
+
+uint32_t pok_space_base_vaddr(uint32_t addr) {
+  /* ARM Cortex-M uses flat memory model - no virtual addressing */
+  return (addr);
+}
+
+uint32_t pok_space_context_create(uint8_t partition_id, uint32_t entry_rel,
+                                  uint8_t processor_affinity,
+                                  uint32_t stack_rel, uint32_t arg1,
+                                  uint32_t arg2) {
+  context_t *ctx;
+  uint32_t entry_abs, stack_abs;
+
+  if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
+    return (0);
+  }
+
+  /* ARM Cortex-M is single-core, ignore processor_affinity but validate it */
+  (void)processor_affinity; /* Suppress unused parameter warning */
+
+  /* Ensure partition was created */
+  if (spaces[partition_id].size == 0) {
+    return (0);
+  }
+
+  /* Bounds validation for entry and stack offsets */
+  /* If partition has a separate code region, validate entry against code region
+   * bounds */
+  if (spaces[partition_id].mpu_code_region != 0) {
+    /* Entry point must be within the code region */
+    uint32_t code_region_base =
+        spaces[partition_id].code_base - spaces[partition_id].phys_base;
+
+    /* Avoid unsigned underflow when computing code_offset */
+    if (entry_rel < code_region_base) {
+      /* entry_rel is before code region - invalid */
+#ifdef POK_NEEDS_DEBUG
+      printf("ERROR: Entry offset 0x%x before code region start 0x%x "
+             "in partition %d\n",
+             entry_rel, code_region_base, partition_id);
+#endif
+      return (0);
+    }
+
+    uint32_t code_offset = entry_rel - code_region_base;
+    if (code_offset >= spaces[partition_id].code_size) {
+#ifdef POK_NEEDS_DEBUG
+      printf("ERROR: Entry offset 0x%x not within code region bounds "
+             "(0x%x-0x%x) in partition %d\n",
+             entry_rel, code_region_base,
+             code_region_base + spaces[partition_id].code_size, partition_id);
+#endif
+      return (0);
+    }
+  } else {
+    /* W^X consistency: require a code region or execution will HardFault */
+#ifdef POK_NEEDS_DEBUG
+    printf(
+        "ERROR: No code region defined for partition %d - execution will fail "
+        "due to W^X enforcement (data region is non-executable)\n",
+        partition_id);
+#endif
+    return (0);
+  }
+
+  if (stack_rel >= spaces[partition_id].size) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Stack offset 0x%x exceeds partition %d size 0x%x\n",
+           stack_rel, partition_id, spaces[partition_id].size);
+#endif
+    return (0);
+  }
+
+  /* Validate that stack has reasonable space (at least 1KB) */
+  uint32_t remaining_stack_space = spaces[partition_id].size - stack_rel;
+  if (remaining_stack_space < 1024) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Insufficient stack space %u bytes in partition %d\n",
+           remaining_stack_space, partition_id);
+#endif
+    return (0);
+  }
+
+  /* Calculate absolute addresses after bounds validation */
+  entry_abs = spaces[partition_id].phys_base + entry_rel;
+  stack_abs = spaces[partition_id].phys_base + stack_rel;
+
+  /* Validate aligned SP is within partition bounds */
+  uint32_t sp_aligned = align_down(stack_abs, STACK_ALIGNMENT_BYTES);
+  uint32_t base = spaces[partition_id].phys_base;
+  uint32_t end = base + spaces[partition_id].size;
+  if (sp_aligned < base || sp_aligned >= end) {
+    return (0);
+  }
+
+  /* Create context frame at top of user stack (no kernel stack allocation) */
+  ctx = (context_t *)(sp_aligned - sizeof(context_t));
+
+  /* Validate context frame is still within partition bounds */
+  if ((uint32_t)ctx < base || ((uint32_t)ctx + sizeof(context_t)) > end) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Context frame outside partition bounds in partition %d\n",
+           partition_id);
+#endif
+    return (0);
+  }
+
+  /* Initialize context frame (zero-initialize first) */
+  memset(ctx, 0, sizeof(context_t));
+
+  /* Initialize ARM Cortex-M context for thread startup */
+  ctx->r0 = arg1;                      /* First argument */
+  ctx->r1 = arg2;                      /* Second argument */
+  ctx->lr = ARM_EXC_RETURN_THREAD_PSP; /* Return to Thread mode, use PSP */
+  ctx->pc = entry_abs | 1;             /* Entry point with Thumb bit set */
+  ctx->xpsr = 0x01000000;              /* Thumb bit set */
+
+#ifdef POK_NEEDS_DEBUG
+  printf("space_context_create %d: entry=%x stack=%x arg1=%x arg2=%x ctx=%x\n",
+         partition_id, entry_abs, stack_abs, arg1, arg2, (uint32_t)ctx);
+#endif
+
+  return (uint32_t)ctx;
+}
+
+pok_ret_t pok_arch_space_init(void) {
+  pok_ret_t ret;
+
+  /* Initialize partition spaces array */
+  memset(spaces, 0, sizeof(spaces));
+
+  /* Reserve region 0 for kernel space */
+  /* Use helper macro for kernel data region */
+  uint32_t kernel_attrs = MPU_CONFIG_KERNEL_DATA;
+  ret = pok_mpu_configure_region(0, pok_bsp_kernel_base(),
+                                 pok_bsp_kernel_size(), kernel_attrs);
+  if (ret != POK_ERRNO_OK) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Failed to configure kernel MPU region: %d\n", ret);
+#endif
+    return ret;
+  }
+
+#ifdef POK_NEEDS_DEBUG
+  printf("pok_arch_space_init: MPU regions=%d\n", pok_mpu_get_region_count());
+#endif
+
+  return POK_ERRNO_OK;
+}

--- a/kernel/arch/arm/space.h
+++ b/kernel/arch/arm/space.h
@@ -1,0 +1,47 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_SPACE_H__
+#define __POK_ARM_SPACE_H__
+
+#include <types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque type; definition lives in space.c */
+struct pok_space;
+typedef struct pok_space pok_space_t;
+
+/* Public API (implemented in kernel/arch/arm/space.c) */
+pok_ret_t pok_arch_space_init(void);
+pok_ret_t pok_create_space(uint8_t partition_id, uint32_t addr, uint32_t size);
+pok_ret_t pok_create_code_region(uint8_t partition_id, uint32_t code_addr,
+                                 uint32_t code_size);
+pok_ret_t pok_space_switch(uint8_t old_partition_id, uint8_t new_partition_id);
+uint32_t pok_space_base_vaddr(uint32_t addr);
+uint32_t pok_space_context_create(uint8_t partition_id, uint32_t entry_rel,
+                                  uint8_t processor_affinity,
+                                  uint32_t stack_rel, uint32_t arg1,
+                                  uint32_t arg2);
+
+/* Exported for inspection/debug if needed (size unspecified). */
+extern pok_space_t spaces[];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __POK_ARM_SPACE_H__ */

--- a/kernel/arch/arm/stm32f4/Makefile
+++ b/kernel/arch/arm/stm32f4/Makefile
@@ -1,0 +1,24 @@
+TOPDIR=		../../../../
+
+include $(TOPDIR)/misc/mk/config.mk
+-include $(TOPDIR)/misc/mk/common-$(ARCH).mk
+
+LO_TARGET=	stm32f4.lo
+
+LO_OBJS=	bsp.o \
+		cons.o \
+		timer.o \
+		startup.o
+
+LO_DEPS=
+
+include $(TOPDIR)/misc/mk/objdir.mk
+
+.PHONY: test
+
+# Optional test target for checkmake compliance
+test: $(LO_TARGET)
+	@echo "STM32F4 BSP build test passed"
+
+include $(TOPDIR)/misc/mk/rules-common.mk
+include $(TOPDIR)/misc/mk/rules-kernel.mk

--- a/kernel/arch/arm/stm32f4/bsp.c
+++ b/kernel/arch/arm/stm32f4/bsp.c
@@ -1,0 +1,292 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/stm32f4/bsp.c
+ * \author  POK team
+ * \brief   STM32F4 Board Support Package
+ */
+
+#include "clock_config.h"
+#include "peripherals.h"
+#include <bsp.h>
+#include <errno.h>
+#include <libc.h>
+
+/* STM32F4-specific memory configuration overrides */
+#define POK_FLASH_BASE STM32F4_FLASH_BASE
+#define POK_SRAM_BASE STM32F4_SRAM_BASE
+
+/* STM32F4 SRAM size - configurable for different MCU variants
+ * STM32F407VG/417VG: 128KB main SRAM + 64KB CCM
+ * STM32F429/439: 256KB main SRAM + 64KB CCM
+ * Override POK_SRAM_SIZE in platform-specific headers if needed */
+#ifndef POK_SRAM_SIZE
+#define POK_SRAM_SIZE 0x20000 /* Default: 128KB for STM32F407/417 */
+#endif
+
+#define POK_KERNEL_MEMORY_SIZE 0x8000 /* 32KB for kernel */
+
+/* Include configurable memory layout */
+#include "../memory_config.h"
+
+/* Forward declarations for STM32F4 specific functions */
+pok_ret_t pok_cons_init(void);
+pok_ret_t pok_timer_init(void);
+pok_ret_t pok_stm32f4_clock_init(void);
+
+/* Simple kernel memory allocator - allocates from kernel space for stacks, etc.
+ */
+static uint32_t current_alloc_addr = POK_KERNEL_MEMORY_BASE;
+
+/**
+ * Initialize STM32F4 Board Support Package
+ *
+ * Sets up system clocks, console UART, and system timer.
+ * Must be called early in system initialization.
+ *
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
+pok_ret_t pok_bsp_init(void) {
+  pok_ret_t ret;
+
+  /* Initialize system clocks */
+  ret = pok_stm32f4_clock_init();
+  if (ret != POK_ERRNO_OK) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Clock initialization failed: %d\n", ret);
+#endif
+    return (ret);
+  }
+
+  /* Initialize console */
+  ret = pok_cons_init();
+  if (ret != POK_ERRNO_OK) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Console initialization failed: %d\n", ret);
+#endif
+    return (ret);
+  }
+
+  /* Initialize timer */
+  ret = pok_timer_init();
+  if (ret != POK_ERRNO_OK) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Timer initialization failed: %d\n", ret);
+#endif
+    return (ret);
+  }
+
+  return POK_ERRNO_OK;
+}
+
+void *pok_bsp_mem_alloc(size_t size) {
+  void *ret;
+
+  if (size == 0) {
+    return (NULL);
+  }
+
+  /* Align to 8-byte boundary */
+  size = (size + POK_MEMORY_ALIGNMENT_MASK) & ~POK_MEMORY_ALIGNMENT_MASK;
+
+  /* Check if we have enough kernel memory remaining - use subtraction to
+   * prevent overflow */
+  uint32_t kernel_end;
+
+  /* Prevent overflow in kernel_end calculation */
+  if (POK_KERNEL_MEMORY_SIZE > (0xFFFFFFFFU - POK_KERNEL_MEMORY_BASE)) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Kernel memory configuration would overflow address space\n");
+#endif
+    return (NULL);
+  }
+
+  kernel_end = POK_KERNEL_MEMORY_BASE + POK_KERNEL_MEMORY_SIZE;
+
+  /* Additional sanity check: ensure current_alloc_addr is within valid kernel
+   * range */
+  if (current_alloc_addr < POK_KERNEL_MEMORY_BASE ||
+      current_alloc_addr > kernel_end) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Kernel allocator corrupted. current_alloc_addr=0x%x\n",
+           current_alloc_addr);
+#endif
+    return (NULL);
+  }
+
+  if (size > (kernel_end - current_alloc_addr)) {
+#ifdef POK_NEEDS_DEBUG
+    printf(
+        "ERROR: Kernel memory exhausted. Requested: %u, Available: %lu\n", size,
+        (POK_KERNEL_MEMORY_BASE + POK_KERNEL_MEMORY_SIZE) - current_alloc_addr);
+#endif
+    return (NULL);
+  }
+
+  ret = (void *)current_alloc_addr;
+  current_alloc_addr += size;
+
+#ifdef POK_NEEDS_DEBUG
+  printf("Allocated %u bytes at 0x%x (kernel space)\n", size, (uint32_t)ret);
+#endif
+
+  return (ret);
+}
+
+uintptr_t pok_bsp_mem_base(void) { return (POK_USER_MEMORY_BASE); }
+
+size_t pok_bsp_mem_size(void) { return (POK_USER_MEMORY_SIZE); }
+
+uintptr_t pok_bsp_kernel_base(void) { return (POK_KERNEL_MEMORY_BASE); }
+
+size_t pok_bsp_kernel_size(void) { return (POK_KERNEL_REGION_SIZE); }
+
+/**
+ * Initialize STM32F4 system clocks
+ * Configures PLL for 168MHz operation using 8MHz HSE crystal
+ *
+ * @return POK_ERRNO_OK on success, error code on failure
+ */
+pok_ret_t pok_stm32f4_clock_init(void) {
+  /* Validate HSE frequency - PLL calculations are hardcoded for 8MHz */
+  if (HSE_FREQ_HZ != 8000000) {
+#ifdef POK_NEEDS_DEBUG
+    printf(
+        "WARNING: HSE frequency is %d Hz, but PLL configuration assumes 8MHz\n",
+        HSE_FREQ_HZ);
+    printf(
+        "         Clock frequencies may be incorrect. Update PLL_M divisor.\n");
+#endif
+  }
+
+  /* Validate USB clock calculation for current HSE */
+  /* USB_CLK = (HSE * PLL_N / PLL_M) / PLL_Q = (HSE * 336 / 8) / 7 */
+  uint32_t calculated_usb_freq = ((uint32_t)HSE_FREQ_HZ * 336U / 8U) / 7U;
+  if (calculated_usb_freq != USB_FREQ_HZ) {
+#ifdef POK_NEEDS_DEBUG
+    printf("WARNING: USB clock will be %d Hz, but USB requires exactly 48MHz\n",
+           calculated_usb_freq);
+    printf("         Adjust PLL_Q divisor if USB functionality is needed.\n");
+#endif
+  }
+
+  volatile uint32_t *RCC_CR =
+      (volatile uint32_t *)(RCC_BASE + 0x00); /* RCC Clock Control Register */
+  volatile uint32_t *RCC_PLLCFGR =
+      (volatile uint32_t *)(RCC_BASE +
+                            0x04); /* RCC PLL Configuration Register */
+  volatile uint32_t *RCC_CFGR =
+      (volatile uint32_t *)(RCC_BASE +
+                            0x08); /* RCC Clock Configuration Register */
+  volatile uint32_t *FLASH_ACR =
+      (volatile uint32_t *)(STM32F4_FLASH_CTRL_BASE +
+                            0x00); /* Flash Access Control Register */
+
+  uint32_t timeout = 0;
+
+  /* Set flash latency for 168MHz operation (5 wait states for 150-168MHz
+   * at 3.3V) */
+  *FLASH_ACR = (*FLASH_ACR & ~0x7) | FLASH_LATENCY;
+
+  /* Enable HSE (High Speed External clock) */
+  *RCC_CR |= (1 << 16); /* HSEON = 1 */
+
+  /* Wait for HSE to be ready */
+  timeout = 10000;
+  while (!((*RCC_CR) & (1 << 17)) && timeout > 0) { /* Wait for HSERDY = 1 */
+    timeout--;
+  }
+
+  if (timeout == 0) {
+    return POK_ERRNO_EFAULT; /* HSE failed to start */
+  }
+
+  /* Configure voltage regulator scaling for 168MHz operation
+   * VOS = Scale 1 mode (required for frequencies > 144 MHz) */
+  volatile uint32_t *PWR_CR = (uint32_t *)STM32F4_PWR_BASE;
+
+  /* Enable PWR clock in RCC */
+  volatile uint32_t *RCC_APB1ENR = (uint32_t *)(STM32F4_RCC_BASE + 0x40);
+  *RCC_APB1ENR |= (1 << 28); /* PWREN = 1 */
+
+  /* Set VOS to Scale 1 (highest performance, required for 168MHz) */
+  *PWR_CR =
+      (*PWR_CR & ~(3 << 14)) | (3 << 14); /* VOS[1:0] = 11 (Scale 1 mode) */
+
+  /* Wait for voltage regulator to be ready */
+  timeout = 1000;
+  volatile uint32_t *PWR_CSR = (uint32_t *)(STM32F4_PWR_BASE + 0x04);
+  while (!((*PWR_CSR) & (1 << 14)) && timeout > 0) { /* Wait for VOSRDY = 1 */
+    timeout--;
+  }
+
+  /* Configure PLL:
+   * PLL_M = 8 (HSE/8 = 1MHz)
+   * PLL_N = 336 (1MHz * 336 = 336MHz)
+   * PLL_P = 2 (336MHz / 2 = 168MHz SYSCLK)
+   * PLL_Q = 7 (336MHz / 7 = 48MHz for USB)
+   * HSE as PLL source
+   */
+  *RCC_PLLCFGR = (7 << 24) |  /* PLL_Q = 7 */
+                 (0 << 16) |  /* PLL_P = 0 (means /2) */
+                 (336 << 6) | /* PLL_N = 336 */
+                 (8 << 0) |   /* PLL_M = 8 */
+                 (1 << 22);   /* HSE as PLL source */
+
+  /* Enable PLL */
+  *RCC_CR |= (1 << 24); /* PLLON = 1 */
+
+  /* Wait for PLL to be ready */
+  timeout = 10000;
+  while (!((*RCC_CR) & (1 << 25)) && timeout > 0) { /* Wait for PLLRDY = 1 */
+    timeout--;
+  }
+
+  if (timeout == 0) {
+    return POK_ERRNO_EFAULT; /* PLL failed to lock */
+  }
+
+  /* Configure bus prescalers:
+   * AHB Prescaler: /1 (168MHz)
+   * APB1 Prescaler: /4 (42MHz, max 42MHz)
+   * APB2 Prescaler: /2 (84MHz, max 84MHz)
+   */
+  *RCC_CFGR = (0x0 << 4) |  /* AHB prescaler /1 */
+              (0x5 << 10) | /* APB1 prescaler /4 */
+              (0x4 << 13);  /* APB2 prescaler /2 */
+
+  /* Switch system clock to PLL */
+  *RCC_CFGR = (*RCC_CFGR & ~0x3) | 0x2; /* SW = 10 (PLL as system clock) */
+
+  /* Wait for PLL to be used as system clock */
+  timeout = 10000;
+  while (((*RCC_CFGR & 0xC) >> 2) != 0x2 &&
+         timeout > 0) { /* Wait for SWS = 10 */
+    timeout--;
+  }
+
+  if (timeout == 0) {
+    return POK_ERRNO_EFAULT; /* Failed to switch to PLL */
+  }
+
+#ifdef POK_NEEDS_DEBUG
+  printf("STM32F4 clock configured: SYSCLK=%dMHz, AHB=%dMHz, APB1=%dMHz, "
+         "APB2=%dMHz\n",
+         SYSCLK_FREQ_HZ / 1000000, AHB_FREQ_HZ / 1000000,
+         APB1_FREQ_HZ / 1000000, APB2_FREQ_HZ / 1000000);
+#endif
+
+  return POK_ERRNO_OK;
+}

--- a/kernel/arch/arm/stm32f4/clock_config.h
+++ b/kernel/arch/arm/stm32f4/clock_config.h
@@ -1,0 +1,79 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_STM32F4_CLOCK_CONFIG_H__
+#define __POK_STM32F4_CLOCK_CONFIG_H__
+
+/**
+ * \file    clock_config.h
+ * \brief   STM32F4 clock configuration constants
+ * \author  POK team
+ *
+ * STM32F407VG typical clock configuration with 8MHz HSE crystal:
+ * - HSE: 8MHz (external crystal)
+ * - PLL_M: 8 (HSE/8 = 1MHz)
+ * - PLL_N: 336 (1MHz * 336 = 336MHz)
+ * - PLL_P: 2 (336MHz / 2 = 168MHz SYSCLK)
+ * - PLL_Q: 7 (336MHz / 7 = 48MHz for USB)
+ * - AHB Prescaler: /1 (168MHz)
+ * - APB1 Prescaler: /4 (42MHz, max 42MHz)
+ * - APB2 Prescaler: /2 (84MHz, max 84MHz)
+ */
+
+/* High-Speed External oscillator frequency */
+#ifndef HSE_FREQ_HZ
+#define HSE_FREQ_HZ 8000000 /* 8MHz crystal on STM32F4DISCOVERY */
+#endif
+
+/* System clock frequencies after PLL configuration */
+#define SYSCLK_FREQ_HZ 168000000 /* Main system clock */
+
+/* Bus prescaler definitions */
+#define AHB_PRESCALER 1  /* AHB Prescaler from SYSCLK */
+#define APB1_PRESCALER 4 /* APB1 Prescaler from SYSCLK */
+#define APB2_PRESCALER 2 /* APB2 Prescaler from SYSCLK */
+
+/* Bus clock frequencies - derived from prescalers */
+#define AHB_FREQ_HZ                                                            \
+  (SYSCLK_FREQ_HZ / AHB_PRESCALER) /* AHB bus clock (HCLK)                     \
+                                    */
+#define APB1_FREQ_HZ                                                           \
+  (AHB_FREQ_HZ / APB1_PRESCALER) /* APB1 bus clock (PCLK1) - max 42MHz */
+#define APB2_FREQ_HZ                                                           \
+  (AHB_FREQ_HZ / APB2_PRESCALER) /* APB2 bus clock (PCLK2) - max 84MHz */
+
+/* Timer clock frequencies - correct calculation based on actual prescaler
+ * values STM32 rule: Timer clock = APBx clock * 2 when APB prescaler > 1,
+ * otherwise APBx clock * 1 Current config: APB1 prescaler = /4 (>1), APB2
+ * prescaler = /2 (>1)
+ */
+
+/* Calculate timer frequencies based on actual prescaler values */
+#define APB1_TIMER_FREQ_HZ                                                     \
+  ((APB1_PRESCALER > 1) ? (APB1_FREQ_HZ * 2)                                   \
+                        : APB1_FREQ_HZ) /* 84MHz when prescaler=4 */
+#define APB2_TIMER_FREQ_HZ                                                     \
+  ((APB2_PRESCALER > 1) ? (APB2_FREQ_HZ * 2)                                   \
+                        : APB2_FREQ_HZ) /* 168MHz when prescaler=2 */
+
+/* SysTick uses SYSCLK by default */
+#define SYSTICK_FREQ_HZ SYSCLK_FREQ_HZ
+
+/* USB clock frequency (must be 48MHz) */
+#define USB_FREQ_HZ 48000000
+
+/* Flash latency for 168MHz operation at 3.3V */
+#define FLASH_LATENCY 5 /* 5 wait states for 150-168MHz */
+
+#endif /* !__POK_STM32F4_CLOCK_CONFIG_H__ */

--- a/kernel/arch/arm/stm32f4/cons.c
+++ b/kernel/arch/arm/stm32f4/cons.c
@@ -1,0 +1,285 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/stm32f4/cons.c
+ * \author  POK team
+ * \brief   STM32F4 console implementation via USART
+ */
+
+#include "clock_config.h"
+#include "peripherals.h"
+#include <errno.h>
+#include <libc.h>
+#include <types.h> /* For pok_ret_t, pok_bool_t, uint32_t, uint64_t */
+
+/* USART configuration constants */
+#define UART_BAUD_RATE 115200
+#define USART_DEFAULT_BAUD_RATE 115200
+#define USART_OVERSAMPLING_FACTOR 16
+#define USART_ROUNDING_DIVISOR 8 /* For rounding in baud rate calculation */
+
+/* STM32F4 USART1 registers */
+/* USART1_BASE now defined in peripherals.h */
+#define USART1_SR (*((volatile uint32_t *)(USART1_BASE + 0x00)))
+#define USART1_DR (*((volatile uint32_t *)(USART1_BASE + 0x04)))
+#define USART1_BRR (*((volatile uint32_t *)(USART1_BASE + 0x08)))
+#define USART1_CR1 (*((volatile uint32_t *)(USART1_BASE + 0x0C)))
+#define USART1_CR2 (*((volatile uint32_t *)(USART1_BASE + 0x10)))
+#define USART1_CR3 (*((volatile uint32_t *)(USART1_BASE + 0x14)))
+
+/* USART status register bits */
+#define USART_SR_TXE (1 << 7)  /* Transmit data register empty */
+#define USART_SR_TC (1 << 6)   /* Transmission complete */
+#define USART_SR_RXNE (1 << 5) /* Read data register not empty */
+#define USART_SR_ORE (1 << 3)  /* Overrun error */
+#define USART_SR_FE (1 << 1)   /* Framing error */
+#define USART_SR_PE (1 << 0)   /* Parity error */
+
+/* USART control register 1 bits */
+#define USART_CR1_UE (1 << 13) /* USART enable */
+#define USART_CR1_TE (1 << 3)  /* Transmitter enable */
+#define USART_CR1_RE (1 << 2)  /* Receiver enable */
+
+/* RCC registers for clock control */
+/* RCC_BASE now defined in peripherals.h */
+#define RCC_APB2ENR (*((volatile uint32_t *)(RCC_BASE + 0x44)))
+#define RCC_AHB1ENR (*((volatile uint32_t *)(RCC_BASE + 0x30)))
+
+#define RCC_APB2ENR_USART1EN (1 << 4)
+#define RCC_AHB1ENR_GPIOAEN (1 << 0)
+
+/* GPIO registers for USART pins */
+/* GPIOA_BASE now defined in peripherals.h */
+#define GPIOA_MODER                                                            \
+  (*((volatile uint32_t *)(GPIOA_BASE + 0x00))) /* Mode register */
+#define GPIOA_OTYPER                                                           \
+  (*((volatile uint32_t *)(GPIOA_BASE + 0x04))) /* Output type register */
+#define GPIOA_OSPEEDR                                                          \
+  (*((volatile uint32_t *)(GPIOA_BASE + 0x08))) /* Output speed register */
+#define GPIOA_PUPDR                                                            \
+  (*((volatile uint32_t *)(GPIOA_BASE + 0x0C))) /* Pull-up/pull-down register  \
+                                                 */
+#define GPIOA_AFRL (*((volatile uint32_t *)(GPIOA_BASE + 0x20))) /* AF[7:0] */
+#define GPIOA_AFRH                                                             \
+  (*((volatile uint32_t *)(GPIOA_BASE + 0x24))) /* AF[15:8]                    \
+                                                 */
+
+/* GPIO pin definitions for PA9 (TX) and PA10 (RX) */
+#define PA9_PIN_POS 9
+#define PA10_PIN_POS 10
+#define PA9_MODER_POS                                                          \
+  (PA9_PIN_POS * 2) /* 18 - Mode register uses 2 bits per pin */
+#define PA10_MODER_POS                                                         \
+  (PA10_PIN_POS * 2) /* 20 - Mode register uses 2 bits per pin */
+/* Define OSPEEDR bit positions (2 bits per pin) */
+#define PA9_OSPEEDR_POS (PA9_PIN_POS * 2)
+#define PA10_OSPEEDR_POS (PA10_PIN_POS * 2)
+#define PA9_AF_POS 4  /* AFRH register: PA9 uses bits 4-7 */
+#define PA10_AF_POS 8 /* AFRH register: PA10 uses bits 8-11 */
+
+/* GPIO mode values */
+#define GPIO_MODE_INPUT 0
+#define GPIO_MODE_OUTPUT 1
+#define GPIO_MODE_AF 2 /* Alternate function */
+#define GPIO_MODE_ANALOG 3
+
+/* GPIO speed values */
+#define GPIO_SPEED_LOW 0       /* 2 MHz */
+#define GPIO_SPEED_MEDIUM 1    /* 25 MHz */
+#define GPIO_SPEED_HIGH 2      /* 50 MHz */
+#define GPIO_SPEED_VERY_HIGH 3 /* 100 MHz */
+
+/* GPIO pull-up/pull-down values */
+#define GPIO_PUPD_NONE 0
+#define GPIO_PUPD_UP 1
+#define GPIO_PUPD_DOWN 2
+
+/* Alternate function values */
+#define GPIO_AF7_USART 7
+
+pok_ret_t pok_cons_init(void) {
+  /* Enable GPIOA and USART1 clocks */
+  RCC_AHB1ENR |= RCC_AHB1ENR_GPIOAEN;
+  RCC_APB2ENR |= RCC_APB2ENR_USART1EN;
+
+  /* Configure PA9 (TX) and PA10 (RX) as alternate function */
+  GPIOA_MODER &= ~((3 << PA9_MODER_POS) |
+                   (3 << PA10_MODER_POS)); /* Clear mode bits for PA9, PA10 */
+  GPIOA_MODER |=
+      (GPIO_MODE_AF << PA9_MODER_POS) |
+      (GPIO_MODE_AF << PA10_MODER_POS); /* Set alternate function mode */
+
+  /* Set alternate function 7 (USART) for PA9 and PA10 */
+  /* PA9 = pin 9 (AFRH bit 4-7), PA10 = pin 10 (AFRH bit 8-11) */
+  GPIOA_AFRH &= ~((0xF << PA9_AF_POS) |
+                  (0xF << PA10_AF_POS)); /* Clear AF bits in AFRH register */
+  GPIOA_AFRH |= (GPIO_AF7_USART << PA9_AF_POS) |
+                (GPIO_AF7_USART << PA10_AF_POS); /* Set AF7 for PA9 and PA10 */
+
+  /* Configure output type as push-pull (default, but explicit) */
+  GPIOA_OTYPER &= ~((1 << PA9_PIN_POS) |
+                    (1 << PA10_PIN_POS)); /* PA9, PA10 push-pull output */
+
+  /* Configure high speed for 115200 baud reliability */
+  GPIOA_OSPEEDR &= ~((3u << PA9_OSPEEDR_POS) |
+                     (3u << PA10_OSPEEDR_POS)); /* Clear speed bits */
+  GPIOA_OSPEEDR |= ((uint32_t)GPIO_SPEED_VERY_HIGH << PA9_OSPEEDR_POS) |
+                   ((uint32_t)GPIO_SPEED_VERY_HIGH
+                    << PA10_OSPEEDR_POS); /* Set very high speed */
+
+  /* Configure pull-up for RX, no pull for TX (USART idle high; TX is driven) */
+  GPIOA_PUPDR &=
+      ~((3 << PA9_MODER_POS) | (3 << PA10_MODER_POS)); /* Clear pull bits */
+  GPIOA_PUPDR |= (GPIO_PUPD_UP
+                  << PA10_MODER_POS); /* PA10 (RX) pull-up, PA9 (TX) no pull */
+  /* Configure USART1 baud rate */
+  /* For oversampling by 16: BRR = (mantissa << 4) + fraction */
+  /* USARTDIV = f_CK / (16 * baud_rate) */
+  uint32_t apb2_clock = APB2_FREQ_HZ; /* Use correct 84MHz APB2 clock */
+  uint32_t baud_rate = USART_DEFAULT_BAUD_RATE;
+
+  /* Bounds checking for baud rate calculation */
+  if (baud_rate == 0) {
+    return POK_ERRNO_EINVAL; /* Avoid division by zero */
+  }
+
+  /* Check for potential overflow in calculation */
+  if (apb2_clock > (0xFFFFFFFFU / USART_OVERSAMPLING_FACTOR)) {
+    return POK_ERRNO_EINVAL; /* Clock frequency too high for safe calculation */
+  }
+
+  /* Use 64-bit arithmetic to prevent overflow during computation */
+  uint64_t numerator = ((uint64_t)apb2_clock * USART_OVERSAMPLING_FACTOR) +
+                       (USART_ROUNDING_DIVISOR * baud_rate);
+  uint64_t denominator = USART_OVERSAMPLING_FACTOR * baud_rate;
+  uint32_t usartdiv_scaled = (uint32_t)(numerator / denominator);
+
+  /* Extract mantissa (integer part) and fraction (4-bit fractional part) */
+  uint32_t mantissa = usartdiv_scaled / USART_OVERSAMPLING_FACTOR;
+  uint32_t fraction = usartdiv_scaled % USART_OVERSAMPLING_FACTOR;
+
+  /* Validate that mantissa fits in 12 bits (STM32F4 BRR register limit) */
+  if (mantissa > 0xFFF) {
+    return POK_ERRNO_EINVAL; /* Baud rate too low for this clock frequency */
+  }
+
+  /* Pack into BRR register format: mantissa[15:4] | fraction[3:0] */
+  USART1_BRR = (mantissa << 4) | (fraction & 0x0F);
+
+  /* Enable USART, transmitter, and receiver */
+  USART1_CR1 = USART_CR1_UE | USART_CR1_TE | USART_CR1_RE;
+
+  return POK_ERRNO_OK;
+}
+
+pok_bool_t pok_cons_write(const char *s, size_t length) {
+  if (s == NULL) {
+    return FALSE;
+  }
+
+  for (size_t i = 0; i < length; i++) {
+    /* Wait for transmit data register to be empty with timeout protection */
+    /* Scale timeout based on APB2 clock (USART1 is on APB2) and baud rate */
+    uint32_t timeout = (APB2_FREQ_HZ / UART_BAUD_RATE) * 10; /* ~10 bit times */
+    while (!(USART1_SR & USART_SR_TXE) && timeout > 0) {
+      timeout--;
+    }
+    if (timeout == 0) {
+#ifdef POK_NEEDS_DEBUG
+      printf("ERROR: UART transmit timeout on character %zu\n", i);
+#endif
+      return FALSE;
+    }
+
+    /* Send character */
+    USART1_DR = (uint8_t)s[i];
+  }
+
+  /* Wait for transmission complete with timeout protection */
+  uint32_t timeout = (APB2_FREQ_HZ / UART_BAUD_RATE) * 10; /* ~10 bit times */
+  while (!(USART1_SR & USART_SR_TC) && timeout > 0) {
+    timeout--;
+  }
+  if (timeout == 0) {
+#ifdef POK_NEEDS_DEBUG
+    printf("WARNING: UART transmission complete timeout\n");
+#endif
+    /* Don't return error for final flush timeout, data likely sent */
+  }
+
+  return TRUE;
+}
+
+pok_ret_t pok_cons_read(char *s, size_t length) {
+  if (s == NULL) {
+    return POK_ERRNO_EINVAL;
+  }
+
+  for (size_t i = 0; i < length; i++) {
+    /* Wait for receive data register to have data with timeout protection */
+    uint32_t timeout =
+        (APB2_FREQ_HZ / UART_BAUD_RATE) * 20; /* ~20 bit times for RX */
+    while (!(USART1_SR & USART_SR_RXNE) && timeout > 0) {
+      timeout--;
+    }
+    if (timeout == 0) {
+#ifdef POK_NEEDS_DEBUG
+      printf("ERROR: UART receive timeout on character %zu\n", i);
+#endif
+      return POK_ERRNO_EFAULT;
+    }
+
+    /* Check and clear UART error conditions (ORE/FE/PE) */
+    uint32_t status = USART1_SR;
+    if (status & (USART_SR_ORE | USART_SR_FE | USART_SR_PE)) {
+      /* Clear errors by reading SR then DR */
+      (void)USART1_SR; /* Reading SR */
+      (void)USART1_DR; /* Reading DR clears error flags */
+#ifdef POK_NEEDS_DEBUG
+      if (status & USART_SR_ORE)
+        printf("UART Overrun Error cleared\n");
+      if (status & USART_SR_FE)
+        printf("UART Framing Error cleared\n");
+      if (status & USART_SR_PE)
+        printf("UART Parity Error cleared\n");
+#endif
+      return POK_ERRNO_EFAULT; /* I/O error */
+    }
+
+    /* Read character */
+    s[i] = USART1_DR & 0xFF;
+  }
+
+  return POK_ERRNO_OK;
+}
+
+/**
+ * Get a single character from console (blocking)
+ *
+ * @param c Pointer to store the received character
+ */
+void pok_cons_get_char(char *c) {
+  if (c == NULL) {
+    return;
+  }
+
+  /* Wait for receive data register to have data */
+  while (!(USART1_SR & USART_SR_RXNE)) {
+    /* Busy wait - no timeout for single char read */
+  }
+
+  /* Read character */
+  *c = (char)(USART1_DR & 0xFF);
+}

--- a/kernel/arch/arm/stm32f4/peripherals.h
+++ b/kernel/arch/arm/stm32f4/peripherals.h
@@ -1,0 +1,61 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_STM32F4_PERIPHERALS_H__
+#define __POK_STM32F4_PERIPHERALS_H__
+
+/**
+ * \file    arch/arm/stm32f4/peripherals.h
+ * \brief   STM32F4 peripheral base addresses and register definitions
+ * \author  POK team
+ */
+
+/* STM32F4 Memory Map */
+#define STM32F4_FLASH_BASE 0x08000000UL
+#define STM32F4_FLASH_SIZE 0x100000UL /* 1MB flash (STM32F407/417) */
+#define STM32F4_SRAM_BASE 0x20000000UL
+#define STM32F4_CCMSRAM_BASE 0x10000000UL
+#define STM32F4_CCMSRAM_SIZE 0x10000UL /* 64KB CCM SRAM (STM32F407/417) */
+
+/* APB1 Peripherals */
+#define STM32F4_APB1_BASE 0x40000000UL
+#define STM32F4_PWR_BASE 0x40007000UL /* Power control for VOS scaling */
+
+/* APB2 Peripherals */
+#define STM32F4_APB2_BASE 0x40010000UL
+#define STM32F4_USART1_BASE 0x40011000UL
+
+/* AHB1 Peripherals */
+#define STM32F4_AHB1_BASE 0x40020000UL
+#define STM32F4_GPIOA_BASE 0x40020000UL
+#define STM32F4_RCC_BASE 0x40023800UL
+
+/* System Control Space */
+#define STM32F4_SCS_BASE 0xE000E000UL
+#define STM32F4_SYSTICK_BASE 0xE000E010UL
+#define STM32F4_NVIC_BASE 0xE000E100UL
+#define STM32F4_SCB_BASE 0xE000ED00UL
+#define STM32F4_MPU_BASE 0xE000ED90UL
+
+/* Flash Control */
+#define STM32F4_FLASH_CTRL_BASE 0x40023C00UL
+
+/* Convenience macros */
+#define USART1_BASE STM32F4_USART1_BASE
+#define GPIOA_BASE STM32F4_GPIOA_BASE
+#define RCC_BASE STM32F4_RCC_BASE
+#define PWR_BASE STM32F4_PWR_BASE /* Power control for VOS scaling */
+#define SYSTICK_BASE STM32F4_SYSTICK_BASE
+
+#endif /* !__POK_STM32F4_PERIPHERALS_H__ */

--- a/kernel/arch/arm/stm32f4/startup.S
+++ b/kernel/arch/arm/stm32f4/startup.S
@@ -1,0 +1,418 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/stm32f4/startup.S
+ * \author  POK team
+ * \brief   STM32F4 startup code and vector table
+ */
+
+.syntax unified
+.cpu cortex-m4
+.thumb
+
+/* Stack top provided by linker script - no duplicate allocation */
+.extern _estack  /* Use linker-provided stack top symbol */
+
+/* Vector table - must be power-of-two aligned for VTOR */
+.section ".isr_vector", "a"
+.align 9  /* 2^9 = 512 bytes, required for 98-vector table */
+.globl vector_table
+vector_table:
+    .word   _estack                     /* Initial Stack Pointer from linker */
+    .word   Reset_Handler               /* Reset Handler */
+    .word   NMI_Handler                 /* NMI Handler */
+    .word   HardFault_Handler           /* Hard Fault Handler */
+    .word   MemManage_Handler           /* Memory Management Fault Handler */
+    .word   BusFault_Handler            /* Bus Fault Handler */
+    .word   UsageFault_Handler          /* Usage Fault Handler */
+    .word   0                           /* Reserved */
+    .word   0                           /* Reserved */
+    .word   0                           /* Reserved */
+    .word   0                           /* Reserved */
+    .word   SVC_Handler                 /* SVCall Handler */
+    .word   DebugMon_Handler            /* Debug Monitor Handler */
+    .word   0                           /* Reserved */
+    .word   PendSV_Handler              /* PendSV Handler */
+    .word   SysTick_Handler             /* SysTick Handler */
+
+    /* External interrupts (STM32F4 specific) */
+    .word   WWDG_IRQHandler                 /* Window WatchDog */
+    .word   PVD_IRQHandler                  /* PVD through EXTI Line detection */
+    .word   TAMP_STAMP_IRQHandler           /* Tamper and TimeStamps through the EXTI line */
+    .word   RTC_WKUP_IRQHandler             /* RTC Wakeup through the EXTI line */
+    .word   FLASH_IRQHandler                /* FLASH */
+    .word   RCC_IRQHandler                  /* RCC */
+    .word   EXTI0_IRQHandler                /* EXTI Line0 */
+    .word   EXTI1_IRQHandler                /* EXTI Line1 */
+    .word   EXTI2_IRQHandler                /* EXTI Line2 */
+    .word   EXTI3_IRQHandler                /* EXTI Line3 */
+    .word   EXTI4_IRQHandler                /* EXTI Line4 */
+    .word   DMA1_Stream0_IRQHandler         /* DMA1 Stream 0 */
+    .word   DMA1_Stream1_IRQHandler         /* DMA1 Stream 1 */
+    .word   DMA1_Stream2_IRQHandler         /* DMA1 Stream 2 */
+    .word   DMA1_Stream3_IRQHandler         /* DMA1 Stream 3 */
+    .word   DMA1_Stream4_IRQHandler         /* DMA1 Stream 4 */
+    .word   DMA1_Stream5_IRQHandler         /* DMA1 Stream 5 */
+    .word   DMA1_Stream6_IRQHandler         /* DMA1 Stream 6 */
+    .word   ADC_IRQHandler                  /* ADC1, ADC2 and ADC3s */
+    .word   CAN1_TX_IRQHandler              /* CAN1 TX */
+    .word   CAN1_RX0_IRQHandler             /* CAN1 RX0 */
+    .word   CAN1_RX1_IRQHandler             /* CAN1 RX1 */
+    .word   CAN1_SCE_IRQHandler             /* CAN1 SCE */
+    .word   EXTI9_5_IRQHandler              /* External Line[9:5]s */
+    .word   TIM1_BRK_TIM9_IRQHandler        /* TIM1 Break and TIM9 */
+    .word   TIM1_UP_TIM10_IRQHandler        /* TIM1 Update and TIM10 */
+    .word   TIM1_TRG_COM_TIM11_IRQHandler   /* TIM1 Trigger and Commutation and TIM11 */
+    .word   TIM1_CC_IRQHandler              /* TIM1 Capture Compare */
+    .word   TIM2_IRQHandler                 /* TIM2 */
+    .word   TIM3_IRQHandler                 /* TIM3 */
+    .word   TIM4_IRQHandler                 /* TIM4 */
+    .word   I2C1_EV_IRQHandler              /* I2C1 Event */
+    .word   I2C1_ER_IRQHandler              /* I2C1 Error */
+    .word   I2C2_EV_IRQHandler              /* I2C2 Event */
+    .word   I2C2_ER_IRQHandler              /* I2C2 Error */
+    .word   SPI1_IRQHandler                 /* SPI1 */
+    .word   SPI2_IRQHandler                 /* SPI2 */
+    .word   USART1_IRQHandler               /* USART1 */
+    .word   USART2_IRQHandler               /* USART2 */
+    .word   USART3_IRQHandler               /* USART3 */
+    .word   EXTI15_10_IRQHandler            /* External Line[15:10]s */
+    .word   RTC_Alarm_IRQHandler            /* RTC Alarm (A and B) through EXTI Line */
+    .word   OTG_FS_WKUP_IRQHandler          /* USB OTG FS Wakeup through EXTI line */
+    .word   TIM8_BRK_TIM12_IRQHandler       /* TIM8 Break and TIM12 */
+    .word   TIM8_UP_TIM13_IRQHandler        /* TIM8 Update and TIM13 */
+    .word   TIM8_TRG_COM_TIM14_IRQHandler   /* TIM8 Trigger and Commutation and TIM14 */
+    .word   TIM8_CC_IRQHandler              /* TIM8 Capture Compare */
+    .word   DMA1_Stream7_IRQHandler         /* DMA1 Stream7 */
+    .word   FSMC_IRQHandler                 /* FSMC */
+    .word   SDIO_IRQHandler                 /* SDIO */
+    .word   TIM5_IRQHandler                 /* TIM5 */
+    .word   SPI3_IRQHandler                 /* SPI3 */
+    .word   UART4_IRQHandler                /* UART4 */
+    .word   UART5_IRQHandler                /* UART5 */
+    .word   TIM6_DAC_IRQHandler             /* TIM6 and DAC1&2 underrun errors */
+    .word   TIM7_IRQHandler                 /* TIM7 */
+    .word   DMA2_Stream0_IRQHandler         /* DMA2 Stream 0 */
+    .word   DMA2_Stream1_IRQHandler         /* DMA2 Stream 1 */
+    .word   DMA2_Stream2_IRQHandler         /* DMA2 Stream 2 */
+    .word   DMA2_Stream3_IRQHandler         /* DMA2 Stream 3 */
+    .word   DMA2_Stream4_IRQHandler         /* DMA2 Stream 4 */
+    .word   ETH_IRQHandler                  /* Ethernet */
+    .word   ETH_WKUP_IRQHandler             /* Ethernet Wakeup through EXTI line */
+    .word   CAN2_TX_IRQHandler              /* CAN2 TX */
+    .word   CAN2_RX0_IRQHandler             /* CAN2 RX0 */
+    .word   CAN2_RX1_IRQHandler             /* CAN2 RX1 */
+    .word   CAN2_SCE_IRQHandler             /* CAN2 SCE */
+    .word   OTG_FS_IRQHandler               /* USB OTG FS */
+    .word   DMA2_Stream5_IRQHandler         /* DMA2 Stream 5 */
+    .word   DMA2_Stream6_IRQHandler         /* DMA2 Stream 6 */
+    .word   DMA2_Stream7_IRQHandler         /* DMA2 Stream 7 */
+    .word   USART6_IRQHandler               /* USART6 */
+    .word   I2C3_EV_IRQHandler              /* I2C3 event */
+    .word   I2C3_ER_IRQHandler              /* I2C3 error */
+    .word   OTG_HS_EP1_OUT_IRQHandler       /* USB OTG HS End Point 1 Out */
+    .word   OTG_HS_EP1_IN_IRQHandler        /* USB OTG HS End Point 1 In */
+    .word   OTG_HS_WKUP_IRQHandler          /* USB OTG HS Wakeup through EXTI */
+    .word   OTG_HS_IRQHandler               /* USB OTG HS */
+    .word   DCMI_IRQHandler                 /* DCMI */
+    .word   CRYP_IRQHandler                 /* CRYP crypto */
+    .word   HASH_RNG_IRQHandler             /* Hash and Rng */
+    .word   FPU_IRQHandler                  /* FPU */
+    .word   UART7_IRQHandler                /* UART7 */
+    .word   UART8_IRQHandler                /* UART8 */
+    .word   SPI4_IRQHandler                 /* SPI4 */
+    .word   SPI5_IRQHandler                 /* SPI5 */
+    .word   SPI6_IRQHandler                 /* SPI6 */
+    .word   SAI1_IRQHandler                 /* SAI1 */
+    .word   LTDC_IRQHandler                 /* LTDC */
+    .word   LTDC_ER_IRQHandler              /* LTDC error */
+    .word   DMA2D_IRQHandler                /* DMA2D */
+
+.text
+.thumb
+.align 2
+
+/* Reset handler */
+.globl Reset_Handler
+.type Reset_Handler, %function
+Reset_Handler:
+    /* Set stack pointer */
+    ldr r0, =_estack
+    mov sp, r0
+
+    /* Initialize data section */
+    ldr r0, =_sdata
+    ldr r1, =_edata
+    ldr r2, =_sidata
+    bl  copy_data
+
+    /* Initialize BSS section */
+    ldr r0, =_sbss
+    ldr r1, =_ebss
+    bl  clear_bss
+
+    /* Call main POK kernel initialization */
+    bl  pok_boot
+
+    /* Should never reach here */
+hang:
+    b   hang
+
+/* Copy data section from flash to RAM */
+copy_data:
+    cmp r0, r1            /* Compare start and end */
+    bge copy_data_done    /* If start >= end, skip */
+copy_data_loop:
+    ldr r3, [r2]          /* Load from flash */
+    str r3, [r0]          /* Store to RAM */
+    adds r0, r0, #4       /* Increment RAM pointer */
+    adds r2, r2, #4       /* Increment flash pointer */
+    cmp r0, r1            /* Compare with end address */
+    blt copy_data_loop    /* Continue if not at end */
+copy_data_done:
+    bx lr
+
+/* Clear BSS section */
+clear_bss:
+    movs r2, #0           /* Clear value */
+    cmp r0, r1            /* Compare start and end */
+    bge clear_bss_done    /* If start >= end, skip */
+clear_bss_loop:
+    str r2, [r0]          /* Clear word */
+    adds r0, r0, #4       /* Increment pointer */
+    cmp r0, r1            /* Compare with end address */
+    blt clear_bss_loop    /* Continue if not at end */
+clear_bss_done:
+    bx lr
+
+/* Default handler for unused interrupts */
+.globl Default_Handler
+.type Default_Handler, %function
+Default_Handler:
+    b Default_Handler
+
+/* Weak aliases for exception handlers */
+.weak NMI_Handler
+.thumb_set NMI_Handler, Default_Handler
+
+.weak HardFault_Handler
+.thumb_set HardFault_Handler, Default_Handler
+
+.weak MemManage_Handler
+.thumb_set MemManage_Handler, Default_Handler
+
+.weak BusFault_Handler
+.thumb_set BusFault_Handler, Default_Handler
+
+.weak UsageFault_Handler
+.thumb_set UsageFault_Handler, Default_Handler
+
+.weak SVC_Handler
+.thumb_set SVC_Handler, Default_Handler
+
+.weak DebugMon_Handler
+.thumb_set DebugMon_Handler, Default_Handler
+
+.weak PendSV_Handler
+.thumb_set PendSV_Handler, Default_Handler
+
+.weak SysTick_Handler
+.thumb_set SysTick_Handler, Default_Handler
+
+/* External interrupt handlers - weak symbols can be overridden */
+.weak WWDG_IRQHandler
+.thumb_set WWDG_IRQHandler, Default_Handler
+.weak PVD_IRQHandler
+.thumb_set PVD_IRQHandler, Default_Handler
+.weak TAMP_STAMP_IRQHandler
+.thumb_set TAMP_STAMP_IRQHandler, Default_Handler
+.weak RTC_WKUP_IRQHandler
+.thumb_set RTC_WKUP_IRQHandler, Default_Handler
+.weak FLASH_IRQHandler
+.thumb_set FLASH_IRQHandler, Default_Handler
+.weak RCC_IRQHandler
+.thumb_set RCC_IRQHandler, Default_Handler
+.weak EXTI0_IRQHandler
+.thumb_set EXTI0_IRQHandler, Default_Handler
+.weak EXTI1_IRQHandler
+.thumb_set EXTI1_IRQHandler, Default_Handler
+.weak EXTI2_IRQHandler
+.thumb_set EXTI2_IRQHandler, Default_Handler
+.weak EXTI3_IRQHandler
+.thumb_set EXTI3_IRQHandler, Default_Handler
+.weak EXTI4_IRQHandler
+.thumb_set EXTI4_IRQHandler, Default_Handler
+.weak DMA1_Stream0_IRQHandler
+.thumb_set DMA1_Stream0_IRQHandler, Default_Handler
+.weak DMA1_Stream1_IRQHandler
+.thumb_set DMA1_Stream1_IRQHandler, Default_Handler
+.weak DMA1_Stream2_IRQHandler
+.thumb_set DMA1_Stream2_IRQHandler, Default_Handler
+.weak DMA1_Stream3_IRQHandler
+.thumb_set DMA1_Stream3_IRQHandler, Default_Handler
+.weak DMA1_Stream4_IRQHandler
+.thumb_set DMA1_Stream4_IRQHandler, Default_Handler
+.weak DMA1_Stream5_IRQHandler
+.thumb_set DMA1_Stream5_IRQHandler, Default_Handler
+.weak DMA1_Stream6_IRQHandler
+.thumb_set DMA1_Stream6_IRQHandler, Default_Handler
+.weak ADC_IRQHandler
+.thumb_set ADC_IRQHandler, Default_Handler
+.weak CAN1_TX_IRQHandler
+.thumb_set CAN1_TX_IRQHandler, Default_Handler
+.weak CAN1_RX0_IRQHandler
+.thumb_set CAN1_RX0_IRQHandler, Default_Handler
+.weak CAN1_RX1_IRQHandler
+.thumb_set CAN1_RX1_IRQHandler, Default_Handler
+.weak CAN1_SCE_IRQHandler
+.thumb_set CAN1_SCE_IRQHandler, Default_Handler
+.weak EXTI9_5_IRQHandler
+.thumb_set EXTI9_5_IRQHandler, Default_Handler
+.weak TIM1_BRK_TIM9_IRQHandler
+.thumb_set TIM1_BRK_TIM9_IRQHandler, Default_Handler
+.weak TIM1_UP_TIM10_IRQHandler
+.thumb_set TIM1_UP_TIM10_IRQHandler, Default_Handler
+.weak TIM1_TRG_COM_TIM11_IRQHandler
+.thumb_set TIM1_TRG_COM_TIM11_IRQHandler, Default_Handler
+.weak TIM1_CC_IRQHandler
+.thumb_set TIM1_CC_IRQHandler, Default_Handler
+.weak TIM2_IRQHandler
+.thumb_set TIM2_IRQHandler, Default_Handler
+.weak TIM3_IRQHandler
+.thumb_set TIM3_IRQHandler, Default_Handler
+.weak TIM4_IRQHandler
+.thumb_set TIM4_IRQHandler, Default_Handler
+.weak I2C1_EV_IRQHandler
+.thumb_set I2C1_EV_IRQHandler, Default_Handler
+.weak I2C1_ER_IRQHandler
+.thumb_set I2C1_ER_IRQHandler, Default_Handler
+.weak I2C2_EV_IRQHandler
+.thumb_set I2C2_EV_IRQHandler, Default_Handler
+.weak I2C2_ER_IRQHandler
+.thumb_set I2C2_ER_IRQHandler, Default_Handler
+.weak SPI1_IRQHandler
+.thumb_set SPI1_IRQHandler, Default_Handler
+.weak SPI2_IRQHandler
+.thumb_set SPI2_IRQHandler, Default_Handler
+.weak USART1_IRQHandler
+.thumb_set USART1_IRQHandler, Default_Handler
+.weak USART2_IRQHandler
+.thumb_set USART2_IRQHandler, Default_Handler
+.weak USART3_IRQHandler
+.thumb_set USART3_IRQHandler, Default_Handler
+.weak EXTI15_10_IRQHandler
+.thumb_set EXTI15_10_IRQHandler, Default_Handler
+.weak RTC_Alarm_IRQHandler
+.thumb_set RTC_Alarm_IRQHandler, Default_Handler
+.weak OTG_FS_WKUP_IRQHandler
+.thumb_set OTG_FS_WKUP_IRQHandler, Default_Handler
+.weak TIM8_BRK_TIM12_IRQHandler
+.thumb_set TIM8_BRK_TIM12_IRQHandler, Default_Handler
+.weak TIM8_UP_TIM13_IRQHandler
+.thumb_set TIM8_UP_TIM13_IRQHandler, Default_Handler
+.weak TIM8_TRG_COM_TIM14_IRQHandler
+.thumb_set TIM8_TRG_COM_TIM14_IRQHandler, Default_Handler
+.weak TIM8_CC_IRQHandler
+.thumb_set TIM8_CC_IRQHandler, Default_Handler
+.weak DMA1_Stream7_IRQHandler
+.thumb_set DMA1_Stream7_IRQHandler, Default_Handler
+.weak FSMC_IRQHandler
+.thumb_set FSMC_IRQHandler, Default_Handler
+.weak SDIO_IRQHandler
+.thumb_set SDIO_IRQHandler, Default_Handler
+.weak TIM5_IRQHandler
+.thumb_set TIM5_IRQHandler, Default_Handler
+.weak SPI3_IRQHandler
+.thumb_set SPI3_IRQHandler, Default_Handler
+.weak UART4_IRQHandler
+.thumb_set UART4_IRQHandler, Default_Handler
+.weak UART5_IRQHandler
+.thumb_set UART5_IRQHandler, Default_Handler
+.weak TIM6_DAC_IRQHandler
+.thumb_set TIM6_DAC_IRQHandler, Default_Handler
+.weak TIM7_IRQHandler
+.thumb_set TIM7_IRQHandler, Default_Handler
+.weak DMA2_Stream0_IRQHandler
+.thumb_set DMA2_Stream0_IRQHandler, Default_Handler
+.weak DMA2_Stream1_IRQHandler
+.thumb_set DMA2_Stream1_IRQHandler, Default_Handler
+.weak DMA2_Stream2_IRQHandler
+.thumb_set DMA2_Stream2_IRQHandler, Default_Handler
+.weak DMA2_Stream3_IRQHandler
+.thumb_set DMA2_Stream3_IRQHandler, Default_Handler
+.weak DMA2_Stream4_IRQHandler
+.thumb_set DMA2_Stream4_IRQHandler, Default_Handler
+.weak ETH_IRQHandler
+.thumb_set ETH_IRQHandler, Default_Handler
+.weak ETH_WKUP_IRQHandler
+.thumb_set ETH_WKUP_IRQHandler, Default_Handler
+.weak CAN2_TX_IRQHandler
+.thumb_set CAN2_TX_IRQHandler, Default_Handler
+.weak CAN2_RX0_IRQHandler
+.thumb_set CAN2_RX0_IRQHandler, Default_Handler
+.weak CAN2_RX1_IRQHandler
+.thumb_set CAN2_RX1_IRQHandler, Default_Handler
+.weak CAN2_SCE_IRQHandler
+.thumb_set CAN2_SCE_IRQHandler, Default_Handler
+.weak OTG_FS_IRQHandler
+.thumb_set OTG_FS_IRQHandler, Default_Handler
+.weak DMA2_Stream5_IRQHandler
+.thumb_set DMA2_Stream5_IRQHandler, Default_Handler
+.weak DMA2_Stream6_IRQHandler
+.thumb_set DMA2_Stream6_IRQHandler, Default_Handler
+.weak DMA2_Stream7_IRQHandler
+.thumb_set DMA2_Stream7_IRQHandler, Default_Handler
+.weak USART6_IRQHandler
+.thumb_set USART6_IRQHandler, Default_Handler
+.weak I2C3_EV_IRQHandler
+.thumb_set I2C3_EV_IRQHandler, Default_Handler
+.weak I2C3_ER_IRQHandler
+.thumb_set I2C3_ER_IRQHandler, Default_Handler
+.weak OTG_HS_EP1_OUT_IRQHandler
+.thumb_set OTG_HS_EP1_OUT_IRQHandler, Default_Handler
+.weak OTG_HS_EP1_IN_IRQHandler
+.thumb_set OTG_HS_EP1_IN_IRQHandler, Default_Handler
+.weak OTG_HS_WKUP_IRQHandler
+.thumb_set OTG_HS_WKUP_IRQHandler, Default_Handler
+.weak OTG_HS_IRQHandler
+.thumb_set OTG_HS_IRQHandler, Default_Handler
+.weak DCMI_IRQHandler
+.thumb_set DCMI_IRQHandler, Default_Handler
+.weak CRYP_IRQHandler
+.thumb_set CRYP_IRQHandler, Default_Handler
+.weak HASH_RNG_IRQHandler
+.thumb_set HASH_RNG_IRQHandler, Default_Handler
+.weak FPU_IRQHandler
+.thumb_set FPU_IRQHandler, Default_Handler
+.weak UART7_IRQHandler
+.thumb_set UART7_IRQHandler, Default_Handler
+.weak UART8_IRQHandler
+.thumb_set UART8_IRQHandler, Default_Handler
+.weak SPI4_IRQHandler
+.thumb_set SPI4_IRQHandler, Default_Handler
+.weak SPI5_IRQHandler
+.thumb_set SPI5_IRQHandler, Default_Handler
+.weak SPI6_IRQHandler
+.thumb_set SPI6_IRQHandler, Default_Handler
+.weak SAI1_IRQHandler
+.thumb_set SAI1_IRQHandler, Default_Handler
+.weak LTDC_IRQHandler
+.thumb_set LTDC_IRQHandler, Default_Handler
+.weak LTDC_ER_IRQHandler
+.thumb_set LTDC_ER_IRQHandler, Default_Handler
+.weak DMA2D_IRQHandler
+.thumb_set DMA2D_IRQHandler, Default_Handler
+
+.end

--- a/kernel/arch/arm/stm32f4/stm32f4.ld
+++ b/kernel/arch/arm/stm32f4/stm32f4.ld
@@ -1,0 +1,130 @@
+/*
+ * STM32F4 Linker Script for POK ARM Cortex-M port
+ * Memory layout for STM32F407VG (1MB Flash, 128KB SRAM)
+ */
+
+ENTRY(Reset_Handler)
+
+/* Memory layout */
+MEMORY
+{
+  FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 1024K
+  SRAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 128K
+  CCMSRAM (rw) : ORIGIN = 0x10000000, LENGTH = 64K  /* Core Coupled Memory for DMA-free data */
+}
+
+/* Stack size definitions */
+_stack_size = 0x1000;  /* 4KB stack - sufficient for ISR nesting, printf, context frames */
+
+/* MSP Placement Note:
+ * Ideally, MSP should be at top of SRAM (0x20000000 + 128K) for optimal memory layout.
+ * However, current design uses mid-SRAM placement to maintain compatibility with
+ * startup.S which defines its own .stack section and __StackTop symbol.
+ * Future enhancement: Modify startup.S to use linker-provided stack location. */
+
+SECTIONS
+{
+  /* Vector table goes to flash - must be 0x200 (512) byte aligned for proper VTOR operation */
+  .isr_vector :
+  {
+    . = ALIGN(0x200);
+    KEEP(*(.isr_vector))
+    /* Note: No additional alignment needed - 512 bytes is already 8-byte aligned */
+  } >FLASH
+
+  /* Program code and constants */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)
+    *(.text*)
+    *(.rodata)
+    *(.rodata*)
+    . = ALIGN(4);
+    _etext = .;
+  } >FLASH
+
+  /* ARM exception unwinding */
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } >FLASH
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  /* Initialized data (copied from flash to RAM at startup) */
+  .data :
+  {
+    . = ALIGN(8);
+    _sdata = .;
+    *(.data)
+    *(.data*)
+    . = ALIGN(8);
+    _edata = .;
+  } >SRAM AT >FLASH
+
+  _sidata = LOADADDR(.data);
+
+  /* Uninitialized data (zero-initialized) */
+  .bss :
+  {
+    . = ALIGN(8);
+    _sbss = .;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(8);
+    _ebss = .;
+
+    /* FIXED: Heap base should be after BSS in SRAM, not in CCMSRAM
+     * This ensures heap is DMA-accessible and in contiguous SRAM */
+    _end = .;
+    PROVIDE(end = .);
+  } >SRAM
+
+  /* Stack section: absorb input .stack from startup.S and allocate space after BSS
+   *
+   * CURRENT DESIGN TRADEOFF:
+   * - Places stack mid-SRAM (after BSS) instead of top-of-SRAM
+   * - RISKS: Heap/stack contention as heap grows upward from _end
+   * - BENEFIT: Maintains compatibility with startup.S __StackTop definition
+   *
+   * FUTURE IMPROVEMENT: Move stack to top-of-SRAM and update startup.S
+   * to use linker-provided stack location for optimal memory layout.
+   * The 4KB stack grows downward from _estack. NOLOAD prevents duplicate allocation. */
+  .stack (NOLOAD) :
+  {
+    . = ALIGN(8);
+    *(.stack)       /* Absorb .stack section from startup.S to prevent orphan */
+    . = . + _stack_size;
+    . = ALIGN(8);
+    _estack = .;  /* Stack top for runtime stack operations */
+  } >SRAM
+
+  /* CCM SRAM section - fast access memory not accessible by DMA
+   * Note: CCMSRAM should NOT contain heap as it's not DMA-accessible
+   * and would cause issues with memory allocators expecting contiguous SRAM */
+  .ccmsram (NOLOAD) :
+  {
+    . = ALIGN(8);
+    _sccmsram = .;
+    *(.ccmsram)
+    *(.ccmsram*)
+    . = ALIGN(8);
+    _eccmsram = .;
+  } >CCMSRAM
+
+  /* Remove specific debugging sections instead of entire libraries */
+  /DISCARD/ :
+  {
+    *(.comment)
+    *(.debug*)
+    *(.note*)
+    *(.eh_frame*)
+  }
+}

--- a/kernel/arch/arm/stm32f4/timer.c
+++ b/kernel/arch/arm/stm32f4/timer.c
@@ -1,0 +1,143 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    arch/arm/stm32f4/timer.c
+ * \author  POK team
+ * \brief   STM32F4 system timer using SysTick
+ */
+
+#include "../../../../test_deployment.h"
+#include "../nvic.h"
+#include "clock_config.h"
+#include "peripherals.h"
+#include <core/sched.h>
+#include <core/time.h>
+#include <errno.h>
+#include <libc.h>
+
+/* SysTick registers */
+/* SYSTICK_BASE now defined in peripherals.h */
+#define SYSTICK_CSR (*((volatile uint32_t *)(SYSTICK_BASE + 0x00)))
+#define SYSTICK_RVR (*((volatile uint32_t *)(SYSTICK_BASE + 0x04)))
+#define SYSTICK_CVR (*((volatile uint32_t *)(SYSTICK_BASE + 0x08)))
+
+/* SysTick Control and Status Register bits */
+#define SYSTICK_CSR_ENABLE (1 << 0)
+#define SYSTICK_CSR_TICKINT (1 << 1)
+#define SYSTICK_CSR_CLKSOURCE (1 << 2)
+
+/* Timer tick frequency (100 Hz = 10ms ticks) */
+#define TIMER_TICK_HZ 100
+#define TIMER_RELOAD_VAL (SYSTICK_FREQ_HZ / TIMER_TICK_HZ)
+
+/* SysTick reload register is 24-bit */
+#define SYSTICK_MAX_RELOAD 0xFFFFFF
+#define SYSTICK_MIN_RELOAD                                                     \
+  100 /* Minimum reasonable reload value for proper timing */
+
+pok_ret_t pok_timer_init(void) {
+  /* Enhanced SysTick reload validation for all clock configurations */
+
+  /* Check for division by zero or invalid tick rate */
+  if (TIMER_TICK_HZ == 0) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: TIMER_TICK_HZ cannot be zero\n");
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Check for invalid system frequency */
+  if (SYSTICK_FREQ_HZ == 0) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: SYSTICK_FREQ_HZ cannot be zero\n");
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Validate reload value is reasonable (not too small) */
+  if (TIMER_RELOAD_VAL < SYSTICK_MIN_RELOAD) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: SysTick reload value %u too small (min %u for stability)\n",
+           TIMER_RELOAD_VAL, SYSTICK_MIN_RELOAD);
+    printf("System freq: %u Hz, Tick rate: %u Hz\n", SYSTICK_FREQ_HZ,
+           TIMER_TICK_HZ);
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Validate SysTick reload value doesn't exceed 24-bit limit */
+  if (TIMER_RELOAD_VAL > SYSTICK_MAX_RELOAD) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: SysTick reload value %u exceeds 24-bit limit %u\n",
+           TIMER_RELOAD_VAL, SYSTICK_MAX_RELOAD);
+    printf("Consider reducing SYSTICK_FREQ_HZ or increasing TIMER_TICK_HZ\n");
+#endif
+    return POK_ERRNO_EINVAL;
+  }
+
+  /* Validate that actual tick frequency will be reasonable - use integer
+   * arithmetic to avoid FP */
+  uint32_t actual_freq = SYSTICK_FREQ_HZ / TIMER_RELOAD_VAL;
+  /* Check tolerance using cross-multiplication: actual_freq * 100 vs
+   * TIMER_TICK_HZ * [95,105] */
+  int64_t actual_freq_scaled = (int64_t)actual_freq * 100;
+  int64_t target_freq_lower = (int64_t)TIMER_TICK_HZ * 95; /* 95% lower bound */
+  int64_t target_freq_upper =
+      (int64_t)TIMER_TICK_HZ * 105; /* 105% upper bound */
+
+  if (actual_freq_scaled < target_freq_lower ||
+      actual_freq_scaled > target_freq_upper) {
+#ifdef POK_NEEDS_DEBUG
+    printf("WARNING: Actual tick frequency %u Hz differs from target %u Hz\n",
+           actual_freq, TIMER_TICK_HZ);
+    printf("Clock configuration may need adjustment\n");
+#endif
+  }
+
+#ifdef POK_NEEDS_DEBUG
+  printf("SysTick: %u Hz system clock, %u Hz tick rate, reload = %u\n",
+         SYSTICK_FREQ_HZ, TIMER_TICK_HZ, TIMER_RELOAD_VAL);
+#endif
+
+  /* Disable SysTick */
+  SYSTICK_CSR = 0;
+
+  /* Set reload value for desired tick rate */
+  SYSTICK_RVR = TIMER_RELOAD_VAL - 1;
+
+  /* Clear current value */
+  SYSTICK_CVR = 0;
+
+  /* Configure SysTick: enable, interrupt, use processor clock */
+  SYSTICK_CSR =
+      SYSTICK_CSR_ENABLE | SYSTICK_CSR_TICKINT | SYSTICK_CSR_CLKSOURCE;
+
+  /* Data Synchronization Barrier to ensure SysTick configuration completes */
+  __asm volatile("dsb" : : : "memory");
+  __asm volatile("isb" : : : "memory");
+
+  return POK_ERRNO_OK;
+}
+
+void pok_timer_handler(void) {
+  /* Clear SysTick interrupt flag (automatically cleared by reading CSR) */
+  (void)SYSTICK_CSR;
+
+  /* Update POK system time */
+  pok_tick_counter++;
+
+  /* Trigger scheduler if needed */
+  (void)pok_sched_end_period();
+}

--- a/kernel/arch/arm/syscalls.c
+++ b/kernel/arch/arm/syscalls.c
@@ -1,0 +1,241 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file kernel/arch/arm/syscalls.c
+ * \brief ARM Cortex-M system call implementation using SVC
+ * \author POK team
+ */
+
+/* POK system headers */
+#include <errno.h>
+
+/* POK core headers */
+#include <core/debug.h>
+#include <core/partition.h>
+#include <core/syscall.h>
+
+/* Architecture-specific headers */
+#include "arch.h"
+#include "mpu.h"
+#include "nvic.h"
+
+/* Extract partition ID from current MPU configuration */
+static uint8_t pok_get_current_partition_id(void) {
+  /* Get active user MPU region */
+  uint8_t active_region = pok_mpu_get_active_user_region();
+
+  /* Region 0 is kernel, user regions start at 1 */
+  if (active_region == 0) {
+    /* Running in kernel mode */
+    extern uint8_t pok_current_partition;
+    return (pok_current_partition);
+  }
+
+  /* Convert region ID back to partition ID (partition_id = region_id - 1) */
+  uint8_t partition_id = active_region - 1;
+
+  /* Validate derived partition ID */
+  if (partition_id >= POK_CONFIG_NB_PARTITIONS) {
+    /* Fallback to global variable if derived ID is invalid */
+    extern uint8_t pok_current_partition;
+    return (pok_current_partition);
+  }
+
+  return (partition_id);
+}
+
+/*
+ * SVC Handler - handles system calls
+ * The SVC number and arguments are passed via registers
+ */
+void SVC_Handler(void) {
+  uint32_t *frame;
+  pok_syscall_info_t syscall_info;
+  pok_ret_t syscall_ret;
+  pok_syscall_args_t *syscall_args;
+  pok_syscall_id_t syscall_id;
+
+  /* Determine which stack pointer to use based on exception context */
+  uint32_t lr_reg;
+  __asm volatile("mov %0, lr" : "=r"(lr_reg));
+
+  /* Check bit 2 of EXC_RETURN (in LR) to determine stack selection:
+   * 0 = MSP (Main Stack Pointer), 1 = PSP (Process Stack Pointer) */
+  if (lr_reg & (1 << 2)) {
+    /* Exception came from Thread mode using PSP */
+    __asm volatile("mrs %0, psp" : "=r"(frame));
+  } else {
+    /* Exception came from Handler mode or Thread mode using MSP */
+    __asm volatile("mrs %0, msp" : "=r"(frame));
+  }
+
+  if (frame == NULL) {
+#ifdef POK_NEEDS_DEBUG
+    printf("ERROR: Invalid stack frame in SVC_Handler\n");
+#endif
+    return; /* Invalid stack frame */
+  }
+
+  /* Extract SVC number from the SVC instruction */
+  uint16_t *svc_addr =
+      (uint16_t *)(frame[6] - 2);       /* PC points to instruction after SVC */
+  uint16_t svc_instruction = *svc_addr; /* Read the 16-bit SVC instruction */
+  uint8_t svc_number =
+      svc_instruction & ARM_SVC_NUMBER_MASK; /* SVC number is in lower 8 bits */
+
+  /* TODO: SVC number could be used for syscall routing/validation in the
+   * future. Currently POK uses a single SVC number (0) for all system calls,
+   * with syscall type determined by register arguments. */
+  (void)svc_number;
+
+  /*
+   * Set up syscall information
+   */
+  syscall_info.partition = pok_get_current_partition_id();
+
+  if (syscall_info.partition >= POK_CONFIG_NB_PARTITIONS) {
+    syscall_ret = POK_ERRNO_EINVAL;
+    goto syscall_exit;
+  }
+
+  syscall_info.base_addr = pok_partitions[syscall_info.partition].base_addr;
+  syscall_info.thread = POK_SCHED_CURRENT_THREAD;
+
+  /*
+   * Get syscall arguments from registers
+   * r0 = syscall_id, r1 = syscall_args pointer (user virtual address)
+   */
+  syscall_id = (pok_syscall_id_t)frame[0]; /* r0 */
+
+  /*
+   * Validate that the arguments pointer is within partition bounds
+   */
+  if (!pok_check_ptr_in_partition(syscall_info.partition, (void *)frame[1],
+                                  sizeof(pok_syscall_args_t))) {
+    syscall_ret = POK_ERRNO_EINVAL;
+    goto syscall_exit;
+  }
+
+  /*
+   * Translate user virtual address to kernel address space
+   * user_vaddr -> kernel_addr = user_vaddr + (base_addr - base_vaddr)
+   */
+  uint32_t user_vaddr = frame[1]; /* r1 - user virtual address */
+  uint32_t base_addr = pok_partitions[syscall_info.partition].base_addr;
+  uint32_t base_vaddr = pok_partitions[syscall_info.partition].base_vaddr;
+
+  /* Check for underflow in offset calculation */
+  if (base_addr < base_vaddr) {
+    syscall_ret = POK_ERRNO_EINVAL; /* Invalid partition configuration */
+    goto syscall_exit;
+  }
+
+  uint32_t kernel_offset = base_addr - base_vaddr;
+
+  /* Check for 32-bit pointer addition overflow using safer arithmetic */
+  if (user_vaddr > (0xFFFFFFFFU - kernel_offset)) {
+    syscall_ret = POK_ERRNO_EINVAL; /* Address overflow */
+    goto syscall_exit;
+  }
+
+  uint32_t kernel_addr = user_vaddr + kernel_offset;
+
+  syscall_args = (pok_syscall_args_t *)kernel_addr;
+
+  /*
+   * Execute the system call
+   */
+  syscall_ret = pok_core_syscall(syscall_id, syscall_args, &syscall_info);
+
+syscall_exit:
+  /*
+   * Return the result in r0
+   */
+  frame[0] = (uint32_t)syscall_ret;
+}
+
+/*
+ * PendSV Handler - handles context switches
+ * This is called when pok_context_switch() triggers the PendSV exception
+ *
+ * NOTE: FPU context not saved since build uses -mfloat-abi=soft
+ * All floating point operations are handled by software libraries
+ */
+void __attribute__((naked)) PendSV_Handler(void) {
+  /* Access global variables from thread.c */
+  extern uint32_t *g_old_sp_ptr;
+  extern uint32_t g_new_sp;
+
+  __asm volatile(
+      /* Save current thread context */
+      "mrs r0, psp                \n" /* Get current Process Stack Pointer */
+      "cbz r0, 1f                 \n" /* Skip if PSP is NULL (first time) */
+
+      "stmdb r0!, {r4-r11}        \n" /* Save r4-r11 (callee-saved regs) */
+
+      /* Store updated PSP to old thread's stack pointer */
+      "ldr r1, =g_old_sp_ptr      \n" /* Load address of g_old_sp_ptr */
+      "ldr r1, [r1]               \n" /* Load g_old_sp_ptr value */
+      "cbz r1, 1f                 \n" /* Skip if NULL */
+      "str r0, [r1]               \n" /* Store new PSP value */
+
+      "1:                         \n" /* Load new thread context */
+      "ldr r0, =g_new_sp          \n" /* Load address of g_new_sp */
+      "ldr r0, [r0]               \n" /* Load g_new_sp value */
+      "cbz r0, 2f                 \n" /* Skip if NULL */
+
+      "ldmia r0!, {r4-r11}        \n" /* Restore r4-r11 from new thread's stack
+                                       */
+      "msr psp, r0                \n" /* Set new Process Stack Pointer */
+
+      "2:                         \n"
+      /* Ensure thread mode with PSP */
+      "ldr r0, =0xFFFFFFFD        \n" /* EXC_RETURN: Return to Thread, use PSP
+                                       */
+      "bx r0                      \n" /* Return from exception */
+
+      ::
+          : "memory");
+}
+
+/*
+ * SysTick Handler - system timer
+ */
+void SysTick_Handler(void) {
+  /* Forward to generic POK timer handler */
+  extern void pok_timer_handler(void);
+  pok_timer_handler();
+}
+
+/**
+ * Initialize system call handling
+ */
+pok_ret_t pok_syscall_init(void) {
+  pok_ret_t ret;
+
+  /* SVC handler is already set in vector table */
+  /* Set up PendSV for context switching */
+  ret = pok_nvic_set_handler(EXCEPTION_PENDSV, PendSV_Handler);
+  if (ret != POK_ERRNO_OK) {
+    return ret;
+  }
+
+  ret = pok_nvic_set_priority(EXCEPTION_PENDSV, NVIC_PRIORITY_LOWEST);
+  if (ret != POK_ERRNO_OK) {
+    return ret;
+  }
+
+  return POK_ERRNO_OK;
+}

--- a/kernel/arch/arm/thread.c
+++ b/kernel/arch/arm/thread.c
@@ -1,0 +1,243 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+/**
+ * \file    thread.c
+ * \brief   ARM Cortex-M thread management and context switching
+ * \author  POK team
+ */
+
+/* POK system headers */
+#include <errno.h>
+#include <libc.h>
+#include <stddef.h>
+
+/* POK core headers */
+#include <bsp.h>
+#include <core/thread.h>
+
+/* Architecture-specific headers */
+#include "arch.h"
+#include "cortex_m_config.h"
+#include "nvic.h"
+#include "thread.h"
+
+#define STACK_ALIGNMENT CORTEX_M_STACK_ALIGNMENT
+#define STACK_ALIGNMENT_MASK CORTEX_M_STACK_ALIGNMENT_MASK
+
+/**
+ * Create a thread context with proper ARM Cortex-M stack frame
+ *
+ * @param thread_id Unique identifier for the thread
+ * @param stack_size Size of stack to allocate in bytes
+ * @param entry Entry point function address for the thread
+ * @return Context pointer on success, 0 on failure
+ */
+uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
+                            uintptr_t entry) {
+  start_context_t *sp;
+  char *stack_addr;
+
+  stack_addr = pok_bsp_mem_alloc(stack_size);
+  if (!stack_addr) {
+    return (0);
+  }
+
+  /* Validate minimum stack size to prevent underflow */
+  if (stack_size < STACK_ALIGNMENT + sizeof(start_context_t)) {
+#ifdef POK_NEEDS_DEBUG
+    printf("Error: stack_size %u too small, minimum required: %u\n", stack_size,
+           (unsigned)(STACK_ALIGNMENT + sizeof(start_context_t)));
+#endif
+    return 0; /* Fail context creation for insufficient stack */
+  }
+
+  /* Place context at top of stack - enforce Cortex-M alignment downward */
+  uint32_t stack_top = stack_addr + stack_size - sizeof(start_context_t);
+  stack_top &= ~STACK_ALIGNMENT_MASK; /* Align to required boundary downward */
+  sp = (start_context_t *)stack_top;
+
+  memset(sp, 0, sizeof(start_context_t));
+
+  /* Initialize context for thread startup */
+  sp->ctx.pc = (uint32_t)pok_arch_thread_start; /* Start with thread wrapper */
+  sp->ctx.lr = ARM_EXC_RETURN_THREAD_PSP; /* Return to Thread mode, use PSP */
+  sp->ctx.xpsr = 0x01000000;              /* Thumb bit set */
+  sp->ctx.r0 = (uint32_t)sp;              /* Pass context pointer via R0 */
+
+  /* CRITICAL FIX: PSP must point TO the saved context frame
+   * For ARM Cortex-M exception return, PSP points to where stack will be
+   * after hardware pops the exception frame (r0-r3,r12,lr,pc,xpsr).
+   *
+   * Stack layout (high to low address):
+   * [stack_addr + stack_size] <- stack top
+   * [...user stack space...]
+   * [hardware frame: xpsr,pc,lr,r12,r3,r2,r1,r0] <- 8 words (32 bytes)
+   * [software frame: r11,r10,r9,r8,r7,r6,r5,r4] <- 8 words (32 bytes)
+   * [start_context_t] <- our context structure
+   *
+   * PSP calculation: initial_psp points to start of hardware frame
+   * for proper exception return
+   */
+  uint32_t initial_psp =
+      (uint32_t)&sp->ctx.r0; /* Points to start of hardware frame */
+
+  /* Verify that hardware frame fits within stack bounds
+   * (PSP management is handled externally) */
+  uint32_t frame_end = initial_psp + (8 * sizeof(uint32_t));
+  if (frame_end > (uint32_t)stack_addr + stack_size) {
+#ifdef POK_NEEDS_DEBUG
+    printf(
+        "Error: hardware frame extends beyond stack bounds [0x%08x, 0x%08x)\n",
+        (uint32_t)stack_addr, (uint32_t)stack_addr + stack_size);
+#endif
+    return 0; /* Fail context creation instead of masking error */
+  }
+
+  /* PSP management is handled externally - context structure only contains
+   * register state */
+
+  sp->entry = entry;
+  sp->id = thread_id;
+
+  return ((uint32_t)sp);
+}
+
+/* Global variables for PendSV context switching - accessed by PendSV handler */
+uint32_t *volatile g_old_sp_ptr = NULL;
+volatile uint32_t g_new_sp = 0;
+/**
+ * Perform ARM Cortex-M context switch between threads
+ *
+ * Uses PendSV exception for proper atomic context switching.
+ * This function sets up the context switch parameters and triggers PendSV.
+ * The actual context switch happens in the PendSV handler.
+ *
+ * @param old_sp Pointer to store current thread's stack pointer
+ * @param new_sp Stack pointer of thread to switch to
+ */
+void pok_context_switch(uint32_t *old_sp, uint32_t new_sp) {
+  if (old_sp == NULL) {
+    return;
+  }
+
+  /* Set up context switch parameters for PendSV handler */
+  g_old_sp_ptr = old_sp;
+  g_new_sp = new_sp;
+
+  /* Ensure memory operations complete before triggering PendSV */
+  __asm volatile("dsb" ::: "memory");
+
+  /* Trigger PendSV exception to perform context switch
+   * Write PENDSVSET directly - avoid RMW to prevent unintended side effects
+   */
+  SCB_ICSR = SCB_ICSR_PENDSVSET;
+
+  /* Memory barrier to ensure PendSV is triggered */
+  __asm volatile("dsb; isb" ::: "memory");
+}
+
+void pok_context_reset(uint32_t stack_size, uint32_t stack_addr) {
+  start_context_t *sp;
+  uint32_t id;
+  uint32_t entry;
+
+  /* Validate minimum stack size to prevent underflow - same as
+   * pok_context_create */
+  if (stack_size < STACK_ALIGNMENT + sizeof(start_context_t)) {
+#ifdef POK_NEEDS_DEBUG
+    printf("Error: reset stack_size %u too small, minimum required: %u\n",
+           stack_size, (unsigned)(STACK_ALIGNMENT + sizeof(start_context_t)));
+#endif
+    return; /* Cannot safely reset context */
+  }
+
+  sp = (start_context_t *)(stack_addr + stack_size - sizeof(start_context_t));
+
+  /* Preserve thread information */
+  id = sp->id;
+  entry = sp->entry;
+
+  /* Reset context */
+  memset(sp, 0, sizeof(start_context_t));
+
+  sp->ctx.pc = (uint32_t)pok_arch_thread_start;
+  sp->ctx.lr = ARM_EXC_RETURN_THREAD_PSP;
+  sp->ctx.xpsr = 0x01000000;
+  sp->ctx.r0 = (uint32_t)sp; /* Pass context pointer via R0 */
+
+  /* Verify that hardware frame fits within stack bounds
+   * (PSP management is handled externally) */
+  uint32_t initial_psp =
+      (uint32_t)&sp->ctx.r0; /* Points to start of hardware frame */
+  uint32_t frame_end = initial_psp + (8 * sizeof(uint32_t));
+  if (frame_end > stack_addr + stack_size) {
+#ifdef POK_NEEDS_DEBUG
+    printf("Error: reset hardware frame extends beyond stack bounds [0x%08x, "
+           "0x%08x)\n",
+           stack_addr, stack_addr + stack_size);
+#endif
+    return; /* Cannot safely reset context */
+  }
+
+  /* PSP management is handled externally - context structure only contains
+   * register state */
+
+  sp->entry = entry;
+  sp->id = id;
+}
+
+/*
+ * Thread startup wrapper
+ * This function is called when a new thread starts execution
+ */
+void pok_arch_thread_start(void) {
+  start_context_t *ctx;
+  uint32_t entry, thread_id;
+
+  /* Get current context from R0 - passed by context creation/reset functions
+   * This avoids complex PSP math and potential reconstruction errors */
+  uint32_t ctx_ptr;
+  __asm volatile("mov %0, r0" : "=r"(ctx_ptr));
+  ctx = (start_context_t *)ctx_ptr;
+
+  /* Extract thread information */
+  entry = ctx->entry;
+  thread_id = ctx->id;
+
+  /* Call POK core thread start function */
+  pok_thread_start((void (*)(void))entry, thread_id);
+
+  /* CRITICAL: Handle thread function return to avoid undefined control flow
+   * In safety-critical systems, threads should not return. If a thread
+   * function returns, we must terminate the thread safely rather than
+   * allowing undefined execution to continue.
+   */
+#ifdef POK_NEEDS_DEBUG
+  printf("FATAL: Thread %d returned from entry function - terminating\n",
+         thread_id);
+#endif
+
+  /* Terminate this thread safely - enter infinite WFI loop
+   * This prevents undefined control flow while keeping the system stable.
+   * The scheduler will never schedule this thread again.
+   */
+  __asm volatile("cpsid i"
+                 :
+                 :
+                 : "memory"); /* Disable interrupts for this thread */
+  while (1) {
+    __asm volatile("wfi"); /* Wait for interrupt (low power) */
+  }
+}

--- a/kernel/arch/arm/thread.h
+++ b/kernel/arch/arm/thread.h
@@ -1,0 +1,84 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_THREAD_H__
+#define __POK_ARM_THREAD_H__
+
+#include <stddef.h>
+#include <types.h>
+
+/*
+ * ARM Cortex-M context structure for PendSV context switching
+ *
+ * LAYOUT CRITICAL: Order must match PendSV handler in syscalls.c
+ *
+ * PendSV Handler Flow:
+ * 1. mrs r0, psp              <- Get current PSP
+ * 2. stmdb r0!, {r4-r11}      <- Push r4-r11 onto thread stack
+ * 3. Store r0 to old thread   <- r0 now points after saved r4-r11
+ * 4. ldmia r0!, {r4-r11}      <- Pop r4-r11 from new thread stack
+ * 5. msr psp, r0              <- Set PSP to point after r4-r11
+ * 6. Hardware pops r0-r3,r12,lr,pc,xpsr from PSP stack on return
+ */
+/* ARM Cortex-M context structure with proper alignment for PendSV context
+ * switching CRITICAL: Structure must maintain 8-byte alignment for stack
+ * operations while ensuring PendSV register layout compatibility
+ */
+typedef struct __attribute__((aligned(8))) {
+  /* SOFTWARE-SAVED: PendSV saves these manually (MUST BE FIRST) */
+  uint32_t r4;
+  uint32_t r5;
+  uint32_t r6;
+  uint32_t r7;
+  uint32_t r8;
+  uint32_t r9;
+  uint32_t r10;
+  uint32_t r11;
+
+  /* HARDWARE-SAVED: Exception hardware pushes these onto PSP stack */
+  uint32_t r0;
+  uint32_t r1;
+  uint32_t r2;
+  uint32_t r3;
+  uint32_t r12;
+  uint32_t lr;   /* Link register */
+  uint32_t pc;   /* Program counter */
+  uint32_t xpsr; /* Program status register */
+
+  /* No PSP field needed - PSP is managed externally by context switcher */
+} context_t;
+
+/* Layout asserts to verify structure integrity */
+_Static_assert(sizeof(context_t) % 8 == 0, "context_t must be 8-byte aligned");
+_Static_assert(offsetof(context_t, r4) == 0, "r4 must be at offset 0");
+_Static_assert(offsetof(context_t, r0) == 8 * 4,
+               "r0 must be at offset 32 (after r4-r11)");
+
+/*
+ * Thread startup context structure - also needs proper alignment
+ */
+typedef struct __attribute__((aligned(8))) {
+  context_t ctx;
+  uint32_t entry; /* Thread entry point */
+  uint32_t id;    /* Thread ID */
+} start_context_t;
+
+/* Function prototypes */
+uint32_t pok_context_create(uint32_t thread_id, uint32_t stack_size,
+                            uintptr_t entry);
+void pok_context_switch(uint32_t *old_sp, uint32_t new_sp);
+void pok_context_reset(uint32_t stack_size, uint32_t stack_addr);
+void pok_arch_thread_start(void);
+
+#endif /* !__POK_ARM_THREAD_H__ */

--- a/kernel/arch/arm/timer.c
+++ b/kernel/arch/arm/timer.c
@@ -1,0 +1,36 @@
+/* Generic ARM timer placeholder; real targets override with strong symbols.
+ *
+ * WEAK SYMBOL DOCUMENTATION:
+ *
+ * These weak implementations provide default no-op behavior for platforms
+ * that don't require custom timer functionality. Real target implementations
+ * should provide strong symbols that override these defaults.
+ *
+ * Override expectations:
+ * - STM32F4 targets: See stm32f4/timer.c for strong implementation
+ * - Other ARM Cortex-M targets: Must provide own timer.c with strong symbols
+ * - pok_timer_init(): Should initialize platform-specific timer hardware
+ * - pok_timer_handler(): Should handle timer interrupts and update
+ * pok_tick_counter
+ *
+ * Impact if not overridden:
+ * - System will compile and link successfully
+ * - No timer interrupts will be generated
+ * - Scheduling timeouts and delays will not work
+ * - Real-time behavior will be lost
+ *
+ * To override: Create timer.c in your platform directory with the same function
+ * signatures but without __attribute__((weak)).
+ */
+#include <errno.h>
+#include <stdint.h>
+#include <types.h>
+
+__attribute__((weak)) pok_ret_t pok_timer_init(void) {
+  /* Default: no-op timer initialization */
+  return POK_ERRNO_OK;
+}
+
+__attribute__((weak)) void pok_timer_handler(void) {
+  /* Default: no-op timer interrupt handler */
+}

--- a/kernel/include/arch.h
+++ b/kernel/include/arch.h
@@ -117,4 +117,8 @@ __attribute__((noreturn)) void pok_division_by_zero_error(void);
 #include <arch/sparc/spinlock.h>
 #endif
 
+#ifdef POK_ARCH_ARM
+/* ARM-specific includes can be added here if needed */
+#endif
+
 #endif /* !__POK_ARCH_H__ */

--- a/kernel/include/arch/arm/types.h
+++ b/kernel/include/arch/arm/types.h
@@ -1,0 +1,34 @@
+/*
+ *                               POK header
+ *
+ * The following file is a part of the POK project. Any modification should
+ * be made according to the POK licence. You CANNOT use this file or a part
+ * of a file for your own project.
+ *
+ * For more information on the POK licence, please see our LICENCE FILE
+ *
+ * Please follow the coding guidelines described in doc/CODING_GUIDELINES
+ *
+ *                                      Copyright (c) 2007-2025 POK team
+ */
+
+#ifndef __POK_ARM_TYPES_H__
+#define __POK_ARM_TYPES_H__
+
+/* Standard integer types for ARM Cortex-M */
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef signed char int8_t;
+typedef signed short int16_t;
+typedef signed int int32_t;
+typedef signed long long int64_t;
+
+/* Pointer types for ARM Cortex-M (32-bit architecture) */
+typedef unsigned int size_t;
+typedef unsigned int uintptr_t;
+typedef signed int intptr_t;
+
+#endif /* !__POK_ARM_TYPES_H__ */

--- a/kernel/include/bsp.h
+++ b/kernel/include/bsp.h
@@ -33,9 +33,15 @@ pok_ret_t pok_bsp_irq_register(uint8_t irq, void (*handler)(void));
 
 void *pok_bsp_mem_alloc(size_t size);
 
+uintptr_t pok_bsp_mem_base(void);
+size_t pok_bsp_mem_size(void);
+uintptr_t pok_bsp_kernel_base(void);
+size_t pok_bsp_kernel_size(void);
+
 pok_ret_t pok_bsp_time_init();
 
-bool_t pok_cons_write(const char *s, size_t length);
+pok_bool_t pok_cons_write(const char *s, size_t length);
+pok_ret_t pok_cons_read(char *s, size_t length);
 
 void pok_cons_get_char(char *c);
 

--- a/kernel/include/types.h
+++ b/kernel/include/types.h
@@ -17,6 +17,8 @@
 
 #ifdef POK_ARCH_SPARC
 #include <arch/sparc/types.h>
+#elif defined(POK_ARCH_ARM) || defined(POK_ARCH_CORTEX_M)
+#include <arch/arm/types.h>
 #elif POK_ARCH == x86
 #include <arch/x86/types.h>
 #endif

--- a/misc/conf-env.pl
+++ b/misc/conf-env.pl
@@ -67,6 +67,20 @@ my %tools_common =
  );
 
 my %tools_arch;
+# ARM toolchain configuration - REQUIRE real cross-toolchain, no host fallbacks
+# Host tools (gcc, ld, objdump, etc.) are removed to prevent incorrect architecture builds
+$tools_arch{"arm"} =
+{
+ "AR" 	      =>  ["arm-none-eabi-ar", "arm-elf-ar"],
+ "CC"          =>  ["arm-none-eabi-gcc", "arm-elf-gcc"],
+ "CXX"	      =>  ["arm-none-eabi-g++", "arm-elf-g++"],
+ "LD"	         =>  ["arm-none-eabi-ld", "arm-elf-ld"],
+ "OBJDUMP"     =>  ["arm-none-eabi-objdump", "arm-elf-objdump"],
+ "OBJCOPY"     =>  ["arm-none-eabi-objcopy", "arm-elf-objcopy"],
+ "RANLIB"      =>  ["arm-none-eabi-ranlib", "arm-elf-ranlib"],
+ "QEMU"        =>  ["qemu-system-arm", "arm-softmmu", "qemu-system-arm"],
+ };
+
 $tools_arch{"x86"} =
 {
  "AR" 	      =>  ["i386-unknown-linux-gnu-ar.exe", "i386-elf-ar" , "ar"],
@@ -152,7 +166,7 @@ my %colors =
       chomp ($line);
 
       ($version) =($line =~ /^[a-zA-Z]+\s([\.0-9a-zA-Z]+)\s.*$/);
-     
+
       if ( "$version" ne "$OCARINA_VERSION")
       {
          print $colors{"RED"}."WARNING: POK required Ocarina version $OCARINA_VERSION, incorrect version \n".$colors{"STD"};
@@ -347,13 +361,13 @@ my %colors =
 
 	sub check_libxml
 	{
-		my $ret = system ("perl -e 'use XML::LibXML;' >/dev/null 2>&1");  
+		my $ret = system ("perl -e 'use XML::LibXML;' >/dev/null 2>&1");
 		if ($ret != 0)
 		{
 			printf "XML::LibXML (Perl XML/LibXML library) not installed, please install it\n";
 			exit 1;
 		}
-			
+
 	}
 
 
@@ -382,19 +396,19 @@ my %colors =
 
    if ($use_floppy == 1)
    {
-      $tools_arch{"x86"}{"MCOPY"} = [ "mcopy"]; 
-      $tools_arch{"x86"}{"MMD"} = [ "mmd"]; 
+      $tools_arch{"x86"}{"MCOPY"} = [ "mcopy"];
+      $tools_arch{"x86"}{"MMD"} = [ "mmd"];
    }
 
    if ($use_xcov == 1)
    {
-      $tools_common{"XCOV"} = [ "xcov"]; 
+      $tools_common{"XCOV"} = [ "xcov"];
    }
 
 
    if ($use_spoq == 1)
    {
-      $tools_arch{"x86"}{"QEMU"} = [ "qemu-spoqed"]; 
+      $tools_arch{"x86"}{"QEMU"} = [ "qemu-spoqed"];
    }
 
 
@@ -403,12 +417,12 @@ my %colors =
 
    my $nb_arch = 0;
 
-   for my $v ("x86", "ppc", "sparc")
+   for my $v ("arm", "x86", "ppc", "sparc")
    {
-      
+
       if (check_arch_tools ($v) == 0)
       {
-         $nb_arch++; 
+         $nb_arch++;
       }
    }
 
@@ -421,13 +435,13 @@ my %colors =
 
    concat_flags ("CONFIG_CFLAGS", @cflags);
    concat_flags ("CONFIG_LDFLAGS", @ldflags);
-   
+
    if ($sys_kind =~ /CYGWIN/ )
    {
       my $tmp_path = `cygpath.exe -d $ENV{PWD}/misc/grub-boot-only.img`;
       chomp ($tmp_path);
       $tmp_path =~ s/\\/\\\\/g;
-      
+
       my $tmp_path2 = `cygpath.exe -d $ENV{PWD}/toolchain/qemu`;
       chomp ($tmp_path2);
       $tmp_path2 =~ s/\\/\\\\/g;
@@ -438,8 +452,8 @@ my %colors =
    {
       $makevars{'CONFIG_QEMU_x86'} = " -fda grub-boot-only.img ";
    }
-   
- 
+
+
    if ($use_instrumentation == 1)
    {
    	print $colors{"GREEN"}."Set instrumentation flag\n".$colors{"STD"};
@@ -453,9 +467,9 @@ my %colors =
 
    if ($use_spoq == 1)
    {
-      $makevars{"SPOQ"} = "1"; 
+      $makevars{"SPOQ"} = "1";
    }
-  
+
    create_env ();
 
    check_ocarina ();
@@ -465,4 +479,3 @@ my %colors =
    print $colors{"GREEN"}."DONE !\n".$colors{"STD"};
 
 # }} Main
-


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
• Adds complete ARM Cortex-M architecture support to the POK kernel
• Implements MPU-based memory protection with W^X enforcement and subregion optimization
• Provides NVIC interrupt controller with vector table relocation and fault handling
• Adds STM32F4 BSP with 168MHz PLL configuration, USART console, and SysTick timer
• Implements context switching using PendSV exception with proper register preservation
• Includes system call handling via SVC exception and comprehensive fault diagnostics
• Adds ARM toolchain configuration and build system integration
• Provides hello world example demonstrating ARM threading capabilities


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ARM Architecture Core"] --> B["MPU Memory Protection"]
  A --> C["NVIC Interrupt Controller"]
  A --> D["Context Switching"]
  B --> E["STM32F4 BSP"]
  C --> E
  D --> E
  E --> F["Console (USART)"]
  E --> G["Timer (SysTick)"]
  E --> H["Clock Config (168MHz)"]
  A --> I["Build System"]
  I --> J["Hello World Example"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>23 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>space.c</strong><dd><code>ARM Cortex-M MPU-based address space management implementation</code></dd></summary>
<hr>

kernel/arch/arm/space.c

• Implements ARM Cortex-M address space management using MPU (Memory <br>Protection Unit)<br> • Provides functions for creating partition memory <br>spaces with W^X enforcement<br> • Includes memory waste validation and <br>subregion support for efficient memory usage<br> • Implements context <br>creation with proper stack alignment and bounds checking


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-503661716d13f0d3893c640fe06f47857552838a5f2452684d255f8cb8d5e468">+495/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nvic.c</strong><dd><code>ARM Cortex-M NVIC interrupt controller implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/nvic.c

• Implements ARM Cortex-M NVIC (Nested Vectored Interrupt Controller) <br>functionality<br> • Provides vector table relocation from Flash to RAM for <br>runtime handler updates<br> • Includes interrupt enable/disable, priority <br>setting, and handler management<br> • Implements fault exception <br>configuration with proper priority settings


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-136d82a1001e6a7e7449ac81b731362569e850d288f62be8aa33278f326d8334">+367/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cons.c</strong><dd><code>STM32F4 USART console implementation with GPIO configuration</code></dd></summary>
<hr>

kernel/arch/arm/stm32f4/cons.c

• Implements STM32F4 console functionality via USART1<br> • Configures <br>GPIO pins PA9/PA10 for UART TX/RX with proper alternate function setup<br> <br>• Provides blocking read/write operations with timeout protection and <br>error handling<br> • Includes baud rate calculation with overflow-safe <br>arithmetic


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-9f06fc54afed08125b622541f4492e285c486cc1441c594505da6ec9d7c0e377">+285/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mpu.c</strong><dd><code>ARM Cortex-M MPU configuration and management implementation</code></dd></summary>
<hr>

kernel/arch/arm/mpu.c

• Implements ARM Cortex-M MPU configuration and management functions<br> • <br>Provides region configuration with power-of-2 size alignment and <br>subregion support<br> • Includes atomic MPU programming with interrupt <br>protection and memory barriers<br> • Implements region enable/disable <br>functionality with proper validation


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-ac159c7a2e3a81d7bace8722687d2af3a9ea877f938272b3ce9c505c53a3fdd6">+374/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bsp.c</strong><dd><code>STM32F4 BSP with clock configuration and memory management</code></dd></summary>
<hr>

kernel/arch/arm/stm32f4/bsp.c

• Implements STM32F4 Board Support Package with system initialization<br> <br>• Configures PLL for 168MHz operation using 8MHz HSE crystal<br> • <br>Provides kernel memory allocator and memory layout configuration<br> • <br>Includes voltage regulator scaling and bus prescaler configuration


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-4307d95478f25c40232a5bc5948cd138e5abf2311b37d12595d02b0f09c78d3e">+292/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exceptions.c</strong><dd><code>ARM Cortex-M exception handling with fault diagnostics</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/exceptions.c

• Implements ARM Cortex-M exception handlers for fault conditions<br> • <br>Provides MemManage, BusFault, UsageFault, and HardFault handlers<br> • <br>Includes non-blocking fault output functions for debugging<br> • <br>Implements system halt on critical faults for safety-critical <br>operation


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-9b59a767984bb4c242d99d931806364738fe58e08d08bf21964f42f74e8fb461">+341/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>thread.c</strong><dd><code>ARM Cortex-M thread context management and switching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/thread.c

• Implements ARM Cortex-M thread context creation and management<br> • <br>Provides context switching using PendSV exception with proper stack <br>handling<br> • Includes thread startup wrapper with proper register <br>initialization<br> • Implements context reset functionality for thread <br>reinitialization


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-220f97179d52374d83450842fdbdd02691f64ee6cfe8f057b30a8073db528af1">+243/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>syscalls.c</strong><dd><code>ARM Cortex-M system call implementation with SVC handling</code></dd></summary>
<hr>

kernel/arch/arm/syscalls.c

• Implements ARM Cortex-M system call handling using SVC exception<br> • <br>Provides PendSV-based context switching with register state <br>preservation<br> • Includes partition ID extraction from MPU configuration<br> <br>• Implements SysTick handler for system timer functionality


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-e97b5ad295875c994e2675fc99859a21b626f78a6fa632e4073c1cf2fc40959f">+241/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mpu.h</strong><dd><code>ARM Cortex-M MPU register definitions and configuration macros</code></dd></summary>
<hr>

kernel/arch/arm/mpu.h

• Defines ARM Cortex-M MPU register definitions and bit masks<br> • <br>Provides memory attribute macros for different memory types<br> • Includes <br>access permission and configuration helper macros<br> • Defines MPU region <br>structure and function prototypes


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-6e06f392f2e8af9c1cdcf57af34eb93a766e4e43e2d81d52927435615a6f53b9">+160/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>timer.c</strong><dd><code>STM32F4 SysTick-based system timer implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/stm32f4/timer.c

• Implements STM32F4 system timer using SysTick<br> • Provides timer <br>initialization with reload value validation<br> • Includes tick frequency <br>configuration and bounds checking<br> • Implements timer interrupt handler <br>for scheduler integration


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-ffe5562ebb01447ceca818289314218875f509ab6c0068fbb8cfafee8d21d38a">+143/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nvic.h</strong><dd><code>ARM Cortex-M NVIC register definitions and constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/nvic.h

• Defines ARM Cortex-M NVIC and SCB register addresses and bit masks<br> • <br>Provides exception number definitions and priority level constants<br> • <br>Includes vector table configuration and function prototypes<br> • Defines <br>system control register bits and interrupt control constants


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-025bd1d4a464a483b93db9a9f56bf7ae56b470d1ab7e3a4cde56ddb454d3ca33">+127/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>arch.c</strong><dd><code>ARM Cortex-M architecture core implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/arch.c

• Implements ARM Cortex-M architecture initialization with <br><code>pok_arch_init()</code> function<br> • Adds preemption control functions using ARM <br>assembly instructions (<code>cpsid i</code>, <code>cpsie i</code>)<br> • Provides thread stack <br>address calculation with overflow protection and alignment<br> • Includes <br>idle function and division-by-zero error handler for testing


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-bc80adf35960e766f6d16d7bfdbfe9e972d3f5c4425608f51d07e18388e8e617">+152/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>thread.h</strong><dd><code>ARM thread context structure and definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/thread.h

• Defines ARM Cortex-M context structure for PendSV context switching<br> <br>• Ensures proper 8-byte alignment for hardware and software saved <br>registers<br> • Includes compile-time assertions to verify structure <br>layout integrity<br> • Provides function prototypes for context management <br>operations


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-28f1e246a68ba549088ba01c0d0a942be977827c5138df12fad4b9d3262d4ad2">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.c</strong><dd><code>ARM Cortex-M hello world example implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/arm-hello/main.c

• Implements simple ARM Cortex-M hello world example with two threads<br> <br>• Creates threads with different sleep intervals for demonstration<br> • <br>Uses POK threading API with proper attribute configuration<br> • Includes <br>partition mode switching to start the scheduler


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-ca1a8686453ccbfc7c3a1500814278b5ef753d577e96cc9175b0f2c00200325b">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>arch.h</strong><dd><code>ARM architecture constants and definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/arch.h

• Defines ARM Cortex-M architecture constants and bit masks<br> • Sets <br>exception return values and register masks for fault handling<br> • <br>Includes priority register configuration with validation<br> • Provides <br>MPU and SVC instruction encoding constants


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-0a960a0d4e8d3b1391609cd2e38945c5eaae7513cba330d702ba66eaf5edd716">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mpu_utils.h</strong><dd><code>MPU utility functions and alignment helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/mpu_utils.h

• Provides shared MPU alignment and utility functions<br> • Implements <br>power-of-2 size alignment for MPU regions<br> • Includes address alignment <br>checking functions<br> • Defines minimum MPU region size constants


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-606491aba0b3fd18cabde6d5d17a20ffe38158819021008efa27e325a0b09364">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>space.h</strong><dd><code>ARM space management API declarations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/space.h

• Defines opaque space type and public API declarations<br> • Provides <br>space initialization and creation function prototypes<br> • Includes space <br>switching and context creation interfaces<br> • Exports spaces array for <br>inspection and debugging


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-d7a02962e181d7d3995a9e0bd62285079b0e8416c041b08d63b62633c7f74d3e">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>timer.c</strong><dd><code>ARM timer weak symbol implementations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/timer.c

• Implements weak symbol timer functions as default no-op behavior<br> • <br>Allows platform-specific timer implementations to override defaults<br> • <br>Documents override expectations and impact of not overriding<br> • <br>Provides fallback for platforms without custom timer functionality


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-924725adad11991b4012a7add8c37dbef29e0d619893b0aeffea5c9e9e5ed337">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.h</strong><dd><code>ARM architecture type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/include/arch/arm/types.h

• Defines standard integer types for ARM Cortex-M architecture<br> • <br>Provides signed and unsigned 8, 16, 32, and 64-bit types<br> • Includes <br>pointer types for 32-bit ARM architecture<br> • Sets size_t and pointer <br>type definitions


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-00853efc24d12c6db3e4fd78d9b663caa06807b78e93aa648ac691cfb8ce6232">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.h</strong><dd><code>ARM architecture integration in type system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/include/types.h

• Adds ARM architecture type inclusion to existing type system<br> • <br>Includes conditional compilation for <code>POK_ARCH_ARM</code> and <br><code>POK_ARCH_CORTEX_M</code><br> • Integrates ARM types with existing SPARC and x86 <br>type definitions


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-be77bc256cedbd2fb204f3314df1a8ec1a88452f234785e332c9e6a6e49cceab">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bsp.h</strong><dd><code>BSP interface extensions for ARM support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/include/bsp.h

• Adds new BSP function declarations for memory management<br> • Includes <br>memory base/size and kernel base/size query functions<br> • Changes <br>console write return type from <code>bool_t</code> to <code>pok_bool_t</code><br> • Adds console <br>read function declaration


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-f3697af3f114294729499e0c4d7f600741d1b0e12873dcf0030c24d992b55c7b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>arch.h</strong><dd><code>ARM architecture integration in arch header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/include/arch.h

• Adds conditional ARM-specific includes to architecture header<br> • <br>Integrates ARM architecture with existing SPARC architecture includes<br> <br>• Provides placeholder for future ARM-specific architecture includes


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-e07cf9f8603d65000b3f357c28d4f418d25481369005ec39a92d4d9be662087f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>startup.S</strong><dd><code>STM32F4 startup assembly and vector table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/stm32f4/startup.S

• Implements STM32F4 startup code with complete vector table<br> • <br>Provides Reset_Handler with data/BSS initialization<br> • Defines all <br>STM32F4 interrupt vectors with weak symbol handlers<br> • Includes proper <br>Cortex-M4 assembly syntax and alignment


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-8eab531e737a63cb41f4101d44261bbaeb0360568b3a788095732a780fb6f78f">+418/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>memory_config.h</strong><dd><code>ARM memory configuration and layout definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/memory_config.h

• Defines configurable memory layout constants for ARM platforms<br> • <br>Sets default STM32F4 memory addresses (flash base, SRAM base/size)<br> • <br>Includes compile-time guards and alignment checks for memory <br>configuration<br> • Provides MPU subregion alignment constants for <br>Cortex-M optimization


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-fdf408dd746adf8e80d72b9f90e9855eeaf1597a41cd1027712960cb0592bc01">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clock_config.h</strong><dd><code>STM32F4 clock configuration constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/stm32f4/clock_config.h

• Defines STM32F4 clock configuration constants for 168MHz operation<br> • <br>Sets PLL parameters and bus prescaler values for optimal performance<br> • <br>Calculates timer frequencies based on APB prescaler configurations<br> • <br>Includes flash latency settings for high-speed operation


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-85552241f32c0be56cadf4eda87a4dd4396106b08c8f08646be9cd9277f5c8a6">+79/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cortex_m_config.h</strong><dd><code>ARM Cortex-M hardware configuration constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/cortex_m_config.h

• Centralizes ARM Cortex-M hardware-specific constants and limits<br> • <br>Defines NVIC vector table configuration with alignment calculations<br> • <br>Sets MPU region limits and stack alignment requirements<br> • Provides <br>exception priority level constants for interrupt handling


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-ddd4f936532f33b78c24eb82883ebb1955762ca5d3c8f824ef6442aa3965bc99">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>peripherals.h</strong><dd><code>STM32F4 peripheral addresses and memory map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/stm32f4/peripherals.h

• Defines STM32F4 peripheral base addresses and memory map<br> • Maps <br>flash, SRAM, and CCM SRAM memory regions<br> • Provides APB1, APB2, and <br>AHB1 peripheral base addresses<br> • Includes system control space and <br>convenience macros


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-0fc4f4099f02b9b442eac642cd94276f0e5b1a98f20efd9f8ccbd82c230d7e78">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conf-env.pl</strong><dd><code>ARM toolchain and build environment configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

misc/conf-env.pl

• Adds ARM toolchain configuration with cross-compilation tools<br> • <br>Requires real ARM cross-toolchain without host fallbacks<br> • Includes <br>ARM architecture in supported architecture list<br> • Adds QEMU ARM system <br>emulation support


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-536fd462eed0589a215eceee3d49a4109631b9bce1de7a9d035ae8ee96d36551">+30/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stm32f4.ld</strong><dd><code>STM32F4 linker script for memory layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/stm32f4/stm32f4.ld

• Implements STM32F4 linker script for memory layout management<br> • <br>Defines flash and SRAM memory regions with proper alignment<br> • Places <br>vector table with required 512-byte alignment for VTOR<br> • Manages stack <br>placement and heap allocation in SRAM


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-ef52462a992a761ec12136bd9363935fb7c77ca22764dab23155ac905180af96">+130/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>ARM architecture build system implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/Makefile

• Creates ARM architecture build system with object compilation<br> • <br>Includes BSP-specific build dependencies and targets<br> • Provides clean, <br>distclean, and dependency generation rules<br> • Supports conditional BSP <br>compilation based on configuration


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-bdac1a5af9db4eace34d3de5ef6943477976cc40b91d881498d1a323bde17671">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.yaml</strong><dd><code>ARM hello world example configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/arm-hello/config.yaml

• Defines ARM hello world example configuration<br> • Sets target <br>architecture to ARM with STM32F4 BSP<br> • Configures single partition <br>with console and threading features<br> • Specifies round-robin scheduler <br>with 1-second time slots


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-7d4e5fd4f50d5e57de74a1e261b9c827cea8c4a828f6400dc8826bd7536172fc">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>STM32F4 BSP build system implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/stm32f4/Makefile

• Implements STM32F4 BSP build system<br> • Compiles BSP, console, timer, <br>and startup object files<br> • Includes standard POK build rules and test <br>targets<br> • Provides clean build environment for STM32F4 platform


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-af6305362d52a26558625c060066519d936c87ab0e9a4d36314b15af04c52738">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>ARM architecture integration in build system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/Makefile

• Adds ARM architecture to supported architecture list<br> • Includes ARM <br>in SUBDIRS for build system integration<br> • Maintains existing PPC, <br>SPARC, and x86 architecture support


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-a0626fa4d61a1ab55fae85239a5e15cbeb73d9bf959e2cb45a22378c7af80ebc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>cons.c</strong><dd><code>ARM console placeholder and documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/cons.c

• Provides minimal ARM console placeholder implementation<br> • Documents <br>BSP-specific console implementation requirements<br> • Explains that <br>actual console drivers are platform-specific<br> • Serves as template for <br>ARM platform console implementations


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-ff9aa84c0db097a85567a22f01ed0e3cc93128f31a9e0aec53d2da541ea0ad95">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>context.h</strong><dd><code>ARM context header placeholder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/context.h

• Creates minimal ARM context header placeholder<br> • Reserved for future <br>ARM context structures and APIs<br> • Intentionally empty to avoid <br>circular includes<br> • References <code>thread.h</code> for actual context definitions


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-cdde13d0a057939a56a304e5bf8f9051e86530f738d9bf8dc13fb0563fd9ade1">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bsp.c</strong><dd><code>ARM BSP placeholder implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kernel/arch/arm/bsp.c

• Creates intentionally empty generic ARM BSP placeholder<br> • Documents <br>that target-specific BSP implementations are required<br> • Explains that <br>actual BSP functions must be provided by platform-specific files


</details>


  </td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-1244ca1635583d23093a42cf9804333eebff40a6b4293c791564b4d0efe59243">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>start.S</strong></td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-b8f8b9d90e49de82340851ba1ca490e765f78ff47fad98e7fbad36b9d7dbab82">[link]</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stm32f4xx_vectors.c</strong></td>
  <td><a href="https://github.com/kaidokert/pok/pull/9/files#diff-39c480a2b70c8428aef155f98f06903499c5e19847b5151ce248c4c60f42c5e1">[link]</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Initial ARM Cortex-M (STM32F4) support: startup, linker, clock, NVIC, MPU with W^X, SysTick timer, exceptions, syscalls, threading/context switching, and memory spaces.
  - New STM32F4 console over USART1.
  - New example: arm-hello demonstrating multi-threading.
- Breaking Changes
  - Console API: write now returns pok_bool_t; added console read function returning pok_ret_t.
- Chores
  - Build/tooling updates to include ARM targets and toolchains; Makefiles extended to build ARM and STM32F4 BSP.
  - Environment script updated for ARM cross-compilers and QEMU.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->